### PR TITLE
ignore tests that fails due to RVIC's internal issues

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,6 @@ python_files = test_*.py
 markers =
 	online: mark test to need internet connection
 	slow: mark test to be slow
-        ignore: mark test to be ignored
 
 [flake8]
 max-line-length = 120

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,6 +31,7 @@ python_files = test_*.py
 markers =
 	online: mark test to need internet connection
 	slow: mark test to be slow
+        ignore: mark test to be ignored
 
 [flake8]
 max-line-length = 120

--- a/tests/test_wps_convolution.py
+++ b/tests/test_wps_convolution.py
@@ -6,13 +6,16 @@ from pkg_resources import resource_filename
 from .common import run_wps_process
 from osprey.processes.wps_convolution import Convolution
 
-
-@mark.slow
-@mark.online
-@mark.ignore  # The test will be ignored until RVIC's internal issues are resolved
-@mark.parametrize(
-    ("config"), [f"{resource_filename(__name__, 'configs/convolve_opendap.cfg')}"],
-)
-def test_wps_convolution(config):
-    params = ("config={0};").format(config)
-    run_wps_process(Convolution(), params)
+#********************************************************************************
+#   The test is disabled due to failues caused by RVIC's internal issues:
+#   https://github.com/UW-Hydro/RVIC/issues/96
+#   https://github.com/UW-Hydro/RVIC/issues/130
+#********************************************************************************
+# @mark.slow
+# @mark.online
+# @mark.parametrize(
+#     ("config"), [f"{resource_filename(__name__, 'configs/convolve_opendap.cfg')}"],
+# )
+# def test_wps_convolution(config):
+#     params = ("config={0};").format(config)
+#     run_wps_process(Convolution(), params)

--- a/tests/test_wps_convolution.py
+++ b/tests/test_wps_convolution.py
@@ -9,6 +9,7 @@ from osprey.processes.wps_convolution import Convolution
 
 @mark.slow
 @mark.online
+@mark.ignore    # The test will be ignored until RVIC's internal issues are resolved
 @mark.parametrize(
     ("config"), [f"{resource_filename(__name__, 'configs/convolve_opendap.cfg')}"],
 )

--- a/tests/test_wps_convolution.py
+++ b/tests/test_wps_convolution.py
@@ -9,7 +9,7 @@ from osprey.processes.wps_convolution import Convolution
 
 @mark.slow
 @mark.online
-@mark.ignore    # The test will be ignored until RVIC's internal issues are resolved
+@mark.ignore  # The test will be ignored until RVIC's internal issues are resolved
 @mark.parametrize(
     ("config"), [f"{resource_filename(__name__, 'configs/convolve_opendap.cfg')}"],
 )

--- a/tests/test_wps_convolution.py
+++ b/tests/test_wps_convolution.py
@@ -6,11 +6,11 @@ from pkg_resources import resource_filename
 from .common import run_wps_process
 from osprey.processes.wps_convolution import Convolution
 
-#********************************************************************************
+# ********************************************************************************
 #   The test is disabled due to failues caused by RVIC's internal issues:
 #   https://github.com/UW-Hydro/RVIC/issues/96
 #   https://github.com/UW-Hydro/RVIC/issues/130
-#********************************************************************************
+# ********************************************************************************
 # @mark.slow
 # @mark.online
 # @mark.parametrize(


### PR DESCRIPTION
This PR resolves #18 

* Included `ignore` marker for pytest
* `test_wps_convolution` is being ignored

@nikola-rados could you change the CI action to run `python3 -m pytest -m "not ignore"` not to show fail(X) sign?