### PR TITLE
Allow dictionary inputs for wps_parameters

### DIFF
--- a/notebooks/demo_individual/demo_convolution.ipynb
+++ b/notebooks/demo_individual/demo_convolution.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -14,7 +14,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -25,7 +25,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -36,15 +36,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
        "\u001b[0;31mType:\u001b[0m            WPSClient\n",
-       "\u001b[0;31mString form:\u001b[0m     <birdy.client.base.WPSClient object at 0x7f1da404f250>\n",
-       "\u001b[0;31mFile:\u001b[0m            ~/Desktop/osprey/venv/lib/python3.7/site-packages/birdy/client/base.py\n",
+       "\u001b[0;31mString form:\u001b[0m     <birdy.client.base.WPSClient object at 0x7f4e00506a20>\n",
+       "\u001b[0;31mFile:\u001b[0m            ~/Desktop/osprey/venv/lib/python3.6/site-packages/birdy/client/base.py\n",
        "\u001b[0;31mDocstring:\u001b[0m      \n",
        "A Web Processing Service for Climate Data Analysis.\n",
        "\n",
@@ -53,6 +53,9 @@
        "\n",
        "convolution\n",
        "    Aggregates the flow contribution from all upstream grid cellsat every timestep lagged according the Impuls Response Functions.\n",
+       "\n",
+       "parameters\n",
+       "    Develop impulse response functions using inputs from a configuration file or dictionary\n",
        "\u001b[0;31mClass docstring:\u001b[0m\n",
        "Returns a class where every public method is a WPS process available at\n",
        "the given url.\n",
@@ -91,7 +94,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -112,7 +115,7 @@
        "-------\n",
        "output : ComplexData:mimetype:`application/x-netcdf`\n",
        "    Output Netcdf File\n",
-       "\u001b[0;31mFile:\u001b[0m      ~/Desktop/osprey/</home/sangwonl/Desktop/osprey/venv/lib/python3.7/site-packages/birdy/client/base.py-0>\n",
+       "\u001b[0;31mFile:\u001b[0m      ~/Desktop/osprey/</home/sangwonl/Desktop/osprey/venv/lib/python3.6/site-packages/birdy/client/base.py-0>\n",
        "\u001b[0;31mType:\u001b[0m      method\n"
       ]
      },
@@ -127,7 +130,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -145,7 +148,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -157,18 +160,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
        "convolutionResponse(\n",
-       "    output='http://localhost:5002/outputs/7a4f56e6-dcdf-11ea-8201-c86000e3f36f/sample.rvic.h0a.2013-01-01.nc'\n",
+       "    output='http://localhost:5002/outputs/951bc6ec-e713-11ea-a3bb-c86000e3f36f/sample.rvic.h0a.2013-01-01.nc'\n",
        ")"
       ]
      },
-     "execution_count": null,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -179,7 +182,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -208,18 +211,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
        "convolutionResponse(\n",
-       "    output='http://localhost:5002/outputs/6f4c90e8-dced-11ea-8201-c86000e3f36f/sample.rvic.h0a.2013-01-01.nc'\n",
+       "    output='http://localhost:5002/outputs/a602bbb4-e713-11ea-a3bb-c86000e3f36f/sample.rvic.h0a.2013-01-01.nc'\n",
        ")"
       ]
      },
-     "execution_count": null,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -252,7 +255,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.5"
+   "version": "3.6.9"
   }
  },
  "nbformat": 4,

--- a/notebooks/demo_individual/demo_parameters.ipynb
+++ b/notebooks/demo_individual/demo_parameters.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -14,7 +14,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -25,7 +25,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -36,14 +36,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
        "\u001b[0;31mType:\u001b[0m            WPSClient\n",
-       "\u001b[0;31mString form:\u001b[0m     <birdy.client.base.WPSClient object at 0x7f2291304048>\n",
+       "\u001b[0;31mString form:\u001b[0m     <birdy.client.base.WPSClient object at 0x7f8ce58f1518>\n",
        "\u001b[0;31mFile:\u001b[0m            ~/Desktop/osprey/venv/lib/python3.6/site-packages/birdy/client/base.py\n",
        "\u001b[0;31mDocstring:\u001b[0m      \n",
        "A Web Processing Service for Climate Data Analysis.\n",
@@ -93,7 +93,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -133,7 +133,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -151,7 +151,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -163,18 +163,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
        "parametersResponse(\n",
-       "    output='http://localhost:5002/outputs/8e21020e-e654-11ea-b58a-c86000e3f36f/sample.rvic.prm.COLUMBIA.20200824.nc'\n",
+       "    output='http://localhost:5002/outputs/f10e5d54-e658-11ea-b58a-c86000e3f36f/sample.rvic.prm.COLUMBIA.20200824.nc'\n",
        ")"
       ]
      },
-     "execution_count": 0,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -185,14 +185,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      " owslib.wps.WPSException : {'code': 'NoApplicableCode', 'locator': 'None', 'text': 'Process failed, please check server error log'}\n"
+     "ename": "ServiceException",
+     "evalue": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<!-- PyWPS 4.2.7 -->\n<ows:ExceptionReport xmlns:ows=\"http://www.opengis.net/ows/1.1\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:schemaLocation=\"http://www.opengis.net/ows/1.1 http://schemas.opengis.net/ows/1.1.0/owsExceptionReport.xsd\" version=\"1.0.0\">\n  <ows:Exception exceptionCode=\"NoApplicableCode\" locator=\"\" >\n      <ows:ExceptionText>Building Response Document failed with : [Errno 2] No such file or directory: '/tmp/pywps_process_qjke6_af/sample/params/sample.rvic.prm.Columibia.20200824.nc'</ows:ExceptionText>\n  </ows:Exception>\n</ows:ExceptionReport>",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mServiceException\u001b[0m                          Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-10-7375b4dad5d2>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m     16\u001b[0m         },\n\u001b[1;32m     17\u001b[0m         \"DOMAIN\": {\n\u001b[0;32m---> 18\u001b[0;31m             \u001b[0;34m\"FILE_NAME\"\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\"https://docker-dev03.pcic.uvic.ca/twitcher/ows/proxy/thredds/dodsC/datasets/RVIC/sample_routing_domain.nc\"\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     19\u001b[0m         },\n\u001b[1;32m     20\u001b[0m     }\n",
+      "\u001b[0;32m</home/sangwonl/Desktop/osprey/venv/lib/python3.6/site-packages/birdy/client/base.py-1>\u001b[0m in \u001b[0;36mparameters\u001b[0;34m(self, config, np, version, loglevel)\u001b[0m\n",
+      "\u001b[0;32m~/Desktop/osprey/venv/lib/python3.6/site-packages/birdy/client/base.py\u001b[0m in \u001b[0;36m_execute\u001b[0;34m(self, pid, **kwargs)\u001b[0m\n\u001b[1;32m    291\u001b[0m         \u001b[0;32mtry\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    292\u001b[0m             wps_response = self._wps.execute(\n\u001b[0;32m--> 293\u001b[0;31m                 \u001b[0mpid\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0minputs\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mwps_inputs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0moutput\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mwps_outputs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmode\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mmode\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    294\u001b[0m             )\n\u001b[1;32m    295\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/Desktop/osprey/venv/lib/python3.6/site-packages/owslib/wps.py\u001b[0m in \u001b[0;36mexecute\u001b[0;34m(self, identifier, inputs, output, mode, lineage, request, response)\u001b[0m\n\u001b[1;32m    357\u001b[0m         \u001b[0;31m# submit the request to the live server\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    358\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0mresponse\u001b[0m \u001b[0;32mis\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 359\u001b[0;31m             \u001b[0mresponse\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mexecution\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0msubmitRequest\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mrequest\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    360\u001b[0m         \u001b[0;32melse\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    361\u001b[0m             \u001b[0mresponse\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0metree\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mfromstring\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mresponse\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/Desktop/osprey/venv/lib/python3.6/site-packages/owslib/wps.py\u001b[0m in \u001b[0;36msubmitRequest\u001b[0;34m(self, request)\u001b[0m\n\u001b[1;32m    910\u001b[0m         \u001b[0mreader\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mWPSExecuteReader\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mverbose\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mverbose\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mtimeout\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mtimeout\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mauth\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mauth\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    911\u001b[0m         response = reader.readFromUrl(\n\u001b[0;32m--> 912\u001b[0;31m             self.url, request, method='Post', headers=self.headers)\n\u001b[0m\u001b[1;32m    913\u001b[0m         \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mresponse\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mresponse\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    914\u001b[0m         \u001b[0;32mreturn\u001b[0m \u001b[0mresponse\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/Desktop/osprey/venv/lib/python3.6/site-packages/owslib/wps.py\u001b[0m in \u001b[0;36mreadFromUrl\u001b[0;34m(self, url, data, method, username, password, headers, verify, cert)\u001b[0m\n\u001b[1;32m    601\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    602\u001b[0m         return self._readFromUrl(url, data, self.timeout, method, username=username, password=password,\n\u001b[0;32m--> 603\u001b[0;31m                                  headers=headers, verify=verify, cert=cert)\n\u001b[0m\u001b[1;32m    604\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    605\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/Desktop/osprey/venv/lib/python3.6/site-packages/owslib/wps.py\u001b[0m in \u001b[0;36m_readFromUrl\u001b[0;34m(self, url, data, timeout, method, username, password, headers, verify, cert)\u001b[0m\n\u001b[1;32m    513\u001b[0m             u = openURL(url, data, method='Post',\n\u001b[1;32m    514\u001b[0m                         \u001b[0musername\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mauth\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0musername\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mpassword\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mauth\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mpassword\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 515\u001b[0;31m                         headers=headers, verify=self.auth.verify, cert=self.auth.cert, timeout=timeout)\n\u001b[0m\u001b[1;32m    516\u001b[0m             \u001b[0;32mreturn\u001b[0m \u001b[0metree\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mfromstring\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mu\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mread\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    517\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/Desktop/osprey/venv/lib/python3.6/site-packages/owslib/util.py\u001b[0m in \u001b[0;36mopenURL\u001b[0;34m(url_base, data, method, cookies, username, password, timeout, headers, verify, cert, auth)\u001b[0m\n\u001b[1;32m    204\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    205\u001b[0m     \u001b[0;32mif\u001b[0m \u001b[0mreq\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mstatus_code\u001b[0m \u001b[0;32min\u001b[0m \u001b[0;34m[\u001b[0m\u001b[0;36m400\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;36m401\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 206\u001b[0;31m         \u001b[0;32mraise\u001b[0m \u001b[0mServiceException\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mreq\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mtext\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    207\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    208\u001b[0m     \u001b[0;32mif\u001b[0m \u001b[0mreq\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mstatus_code\u001b[0m \u001b[0;32min\u001b[0m \u001b[0;34m[\u001b[0m\u001b[0;36m404\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;36m500\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;36m502\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;36m503\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;36m504\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m:\u001b[0m    \u001b[0;31m# add more if needed\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mServiceException\u001b[0m: <?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<!-- PyWPS 4.2.7 -->\n<ows:ExceptionReport xmlns:ows=\"http://www.opengis.net/ows/1.1\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:schemaLocation=\"http://www.opengis.net/ows/1.1 http://schemas.opengis.net/ows/1.1.0/owsExceptionReport.xsd\" version=\"1.0.0\">\n  <ows:Exception exceptionCode=\"NoApplicableCode\" locator=\"\" >\n      <ows:ExceptionText>Building Response Document failed with : [Errno 2] No such file or directory: '/tmp/pywps_process_qjke6_af/sample/params/sample.rvic.prm.Columibia.20200824.nc'</ows:ExceptionText>\n  </ows:Exception>\n</ows:ExceptionReport>"
      ]
     }
    ],
@@ -202,7 +213,7 @@
     "    config = {\n",
     "        \"OPTIONS\":{\n",
     "            \"CASEID\":\"sample\", \n",
-    "            \"GRIDID\":\"Columibia\",\n",
+    "            \"GRIDID\":\"COLUMBIA\",\n",
     "        },\n",
     "        \"POUR_POINTS\":{\n",
     "            \"FILE_NAME\":\"https://docker-dev03.pcic.uvic.ca/twitcher/ows/proxy/thredds/dodsC/datasets/RVIC/sample_pour.txt\"\n",

--- a/notebooks/demo_individual/demo_parameters.ipynb
+++ b/notebooks/demo_individual/demo_parameters.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 0,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -14,7 +14,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 0,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -25,7 +25,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 0,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -36,15 +36,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 0,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
        "\u001b[0;31mType:\u001b[0m            WPSClient\n",
-       "\u001b[0;31mString form:\u001b[0m     <birdy.client.base.WPSClient object at 0x7fa7f84f42e8>\n",
-       "\u001b[0;31mFile:\u001b[0m            ~/osprey-venv/lib/python3.6/site-packages/birdy/client/base.py\n",
+       "\u001b[0;31mString form:\u001b[0m     <birdy.client.base.WPSClient object at 0x7f2291304048>\n",
+       "\u001b[0;31mFile:\u001b[0m            ~/Desktop/osprey/venv/lib/python3.6/site-packages/birdy/client/base.py\n",
        "\u001b[0;31mDocstring:\u001b[0m      \n",
        "A Web Processing Service for Climate Data Analysis.\n",
        "\n",
@@ -93,7 +93,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 0,
    "metadata": {},
    "outputs": [
     {
@@ -118,7 +118,7 @@
        "-------\n",
        "output : ComplexData:mimetype:`application/x-netcdf`\n",
        "    Output Netcdf File\n",
-       "\u001b[0;31mFile:\u001b[0m      ~/osprey/</home/slim/osprey-venv/lib/python3.6/site-packages/birdy/client/base.py-1>\n",
+       "\u001b[0;31mFile:\u001b[0m      ~/Desktop/osprey/</home/sangwonl/Desktop/osprey/venv/lib/python3.6/site-packages/birdy/client/base.py-1>\n",
        "\u001b[0;31mType:\u001b[0m      method\n"
       ]
      },
@@ -133,14 +133,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 0,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "/home/slim/osprey/tests/data/samples/sample_parameter_config.cfg\n"
+      "/home/sangwonl/Desktop/osprey/tests/data/samples/sample_parameter_config.cfg\n"
      ]
     }
    ],
@@ -151,7 +151,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 0,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -163,18 +163,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 0,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
        "parametersResponse(\n",
-       "    output='http://localhost:5002/outputs/22f2799c-dc02-11ea-a870-c86000e3f2fd/sample.rvic.prm.COLUMBIA.20200811.nc'\n",
+       "    output='http://localhost:5002/outputs/8e21020e-e654-11ea-b58a-c86000e3f36f/sample.rvic.prm.COLUMBIA.20200824.nc'\n",
        ")"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 0,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -182,6 +182,50 @@
    "source": [
     "output.get()"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " owslib.wps.WPSException : {'code': 'NoApplicableCode', 'locator': 'None', 'text': 'Process failed, please check server error log'}\n"
+     ]
+    }
+   ],
+   "source": [
+    "# generate convolution\n",
+    "output = osprey.parameters(\n",
+    "    config = {\n",
+    "        \"OPTIONS\":{\n",
+    "            \"CASEID\":\"sample\", \n",
+    "            \"GRIDID\":\"Columibia\",\n",
+    "        },\n",
+    "        \"POUR_POINTS\":{\n",
+    "            \"FILE_NAME\":\"https://docker-dev03.pcic.uvic.ca/twitcher/ows/proxy/thredds/dodsC/datasets/RVIC/sample_pour.txt\"\n",
+    "        },\n",
+    "        \"UH_BOX\":{\n",
+    "            \"FILE_NAME\":\"https://docker-dev03.pcic.uvic.ca/twitcher/ows/proxy/thredds/dodsC/datasets/RVIC/uhbox.csv\"\n",
+    "        },\n",
+    "        \"ROUTING\": {\n",
+    "            \"FILE_NAME\":\"https://docker-dev03.pcic.uvic.ca/twitcher/ows/proxy/thredds/dodsC/datasets/RVIC/sample_flow_parameters.nc\"\n",
+    "        },\n",
+    "        \"DOMAIN\": {\n",
+    "            \"FILE_NAME\":\"https://docker-dev03.pcic.uvic.ca/twitcher/ows/proxy/thredds/dodsC/datasets/RVIC/sample_routing_domain.nc\"\n",
+    "        },\n",
+    "    }\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/notebooks/demo_individual/demo_parameters.ipynb
+++ b/notebooks/demo_individual/demo_parameters.ipynb
@@ -43,7 +43,7 @@
      "data": {
       "text/plain": [
        "\u001b[0;31mType:\u001b[0m            WPSClient\n",
-       "\u001b[0;31mString form:\u001b[0m     <birdy.client.base.WPSClient object at 0x7f8ce58f1518>\n",
+       "\u001b[0;31mString form:\u001b[0m     <birdy.client.base.WPSClient object at 0x7f6f493ea2e8>\n",
        "\u001b[0;31mFile:\u001b[0m            ~/Desktop/osprey/venv/lib/python3.6/site-packages/birdy/client/base.py\n",
        "\u001b[0;31mDocstring:\u001b[0m      \n",
        "A Web Processing Service for Climate Data Analysis.\n",
@@ -170,7 +170,7 @@
      "data": {
       "text/plain": [
        "parametersResponse(\n",
-       "    output='http://localhost:5002/outputs/f10e5d54-e658-11ea-b58a-c86000e3f36f/sample.rvic.prm.COLUMBIA.20200824.nc'\n",
+       "    output='http://localhost:5002/outputs/b7be4b48-e713-11ea-a3bb-c86000e3f36f/sample.rvic.prm.COLUMBIA.20200825.nc'\n",
        ")"
       ]
      },
@@ -185,25 +185,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
-     "ename": "ServiceException",
-     "evalue": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<!-- PyWPS 4.2.7 -->\n<ows:ExceptionReport xmlns:ows=\"http://www.opengis.net/ows/1.1\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:schemaLocation=\"http://www.opengis.net/ows/1.1 http://schemas.opengis.net/ows/1.1.0/owsExceptionReport.xsd\" version=\"1.0.0\">\n  <ows:Exception exceptionCode=\"NoApplicableCode\" locator=\"\" >\n      <ows:ExceptionText>Building Response Document failed with : [Errno 2] No such file or directory: '/tmp/pywps_process_qjke6_af/sample/params/sample.rvic.prm.Columibia.20200824.nc'</ows:ExceptionText>\n  </ows:Exception>\n</ows:ExceptionReport>",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mServiceException\u001b[0m                          Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-10-7375b4dad5d2>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m     16\u001b[0m         },\n\u001b[1;32m     17\u001b[0m         \"DOMAIN\": {\n\u001b[0;32m---> 18\u001b[0;31m             \u001b[0;34m\"FILE_NAME\"\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\"https://docker-dev03.pcic.uvic.ca/twitcher/ows/proxy/thredds/dodsC/datasets/RVIC/sample_routing_domain.nc\"\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     19\u001b[0m         },\n\u001b[1;32m     20\u001b[0m     }\n",
-      "\u001b[0;32m</home/sangwonl/Desktop/osprey/venv/lib/python3.6/site-packages/birdy/client/base.py-1>\u001b[0m in \u001b[0;36mparameters\u001b[0;34m(self, config, np, version, loglevel)\u001b[0m\n",
-      "\u001b[0;32m~/Desktop/osprey/venv/lib/python3.6/site-packages/birdy/client/base.py\u001b[0m in \u001b[0;36m_execute\u001b[0;34m(self, pid, **kwargs)\u001b[0m\n\u001b[1;32m    291\u001b[0m         \u001b[0;32mtry\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    292\u001b[0m             wps_response = self._wps.execute(\n\u001b[0;32m--> 293\u001b[0;31m                 \u001b[0mpid\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0minputs\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mwps_inputs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0moutput\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mwps_outputs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmode\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mmode\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    294\u001b[0m             )\n\u001b[1;32m    295\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m~/Desktop/osprey/venv/lib/python3.6/site-packages/owslib/wps.py\u001b[0m in \u001b[0;36mexecute\u001b[0;34m(self, identifier, inputs, output, mode, lineage, request, response)\u001b[0m\n\u001b[1;32m    357\u001b[0m         \u001b[0;31m# submit the request to the live server\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    358\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0mresponse\u001b[0m \u001b[0;32mis\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 359\u001b[0;31m             \u001b[0mresponse\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mexecution\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0msubmitRequest\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mrequest\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    360\u001b[0m         \u001b[0;32melse\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    361\u001b[0m             \u001b[0mresponse\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0metree\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mfromstring\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mresponse\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m~/Desktop/osprey/venv/lib/python3.6/site-packages/owslib/wps.py\u001b[0m in \u001b[0;36msubmitRequest\u001b[0;34m(self, request)\u001b[0m\n\u001b[1;32m    910\u001b[0m         \u001b[0mreader\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mWPSExecuteReader\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mverbose\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mverbose\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mtimeout\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mtimeout\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mauth\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mauth\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    911\u001b[0m         response = reader.readFromUrl(\n\u001b[0;32m--> 912\u001b[0;31m             self.url, request, method='Post', headers=self.headers)\n\u001b[0m\u001b[1;32m    913\u001b[0m         \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mresponse\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mresponse\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    914\u001b[0m         \u001b[0;32mreturn\u001b[0m \u001b[0mresponse\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m~/Desktop/osprey/venv/lib/python3.6/site-packages/owslib/wps.py\u001b[0m in \u001b[0;36mreadFromUrl\u001b[0;34m(self, url, data, method, username, password, headers, verify, cert)\u001b[0m\n\u001b[1;32m    601\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    602\u001b[0m         return self._readFromUrl(url, data, self.timeout, method, username=username, password=password,\n\u001b[0;32m--> 603\u001b[0;31m                                  headers=headers, verify=verify, cert=cert)\n\u001b[0m\u001b[1;32m    604\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    605\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m~/Desktop/osprey/venv/lib/python3.6/site-packages/owslib/wps.py\u001b[0m in \u001b[0;36m_readFromUrl\u001b[0;34m(self, url, data, timeout, method, username, password, headers, verify, cert)\u001b[0m\n\u001b[1;32m    513\u001b[0m             u = openURL(url, data, method='Post',\n\u001b[1;32m    514\u001b[0m                         \u001b[0musername\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mauth\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0musername\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mpassword\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mauth\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mpassword\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 515\u001b[0;31m                         headers=headers, verify=self.auth.verify, cert=self.auth.cert, timeout=timeout)\n\u001b[0m\u001b[1;32m    516\u001b[0m             \u001b[0;32mreturn\u001b[0m \u001b[0metree\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mfromstring\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mu\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mread\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    517\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m~/Desktop/osprey/venv/lib/python3.6/site-packages/owslib/util.py\u001b[0m in \u001b[0;36mopenURL\u001b[0;34m(url_base, data, method, cookies, username, password, timeout, headers, verify, cert, auth)\u001b[0m\n\u001b[1;32m    204\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    205\u001b[0m     \u001b[0;32mif\u001b[0m \u001b[0mreq\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mstatus_code\u001b[0m \u001b[0;32min\u001b[0m \u001b[0;34m[\u001b[0m\u001b[0;36m400\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;36m401\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 206\u001b[0;31m         \u001b[0;32mraise\u001b[0m \u001b[0mServiceException\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mreq\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mtext\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    207\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    208\u001b[0m     \u001b[0;32mif\u001b[0m \u001b[0mreq\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mstatus_code\u001b[0m \u001b[0;32min\u001b[0m \u001b[0;34m[\u001b[0m\u001b[0;36m404\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;36m500\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;36m502\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;36m503\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;36m504\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m:\u001b[0m    \u001b[0;31m# add more if needed\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;31mServiceException\u001b[0m: <?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<!-- PyWPS 4.2.7 -->\n<ows:ExceptionReport xmlns:ows=\"http://www.opengis.net/ows/1.1\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:schemaLocation=\"http://www.opengis.net/ows/1.1 http://schemas.opengis.net/ows/1.1.0/owsExceptionReport.xsd\" version=\"1.0.0\">\n  <ows:Exception exceptionCode=\"NoApplicableCode\" locator=\"\" >\n      <ows:ExceptionText>Building Response Document failed with : [Errno 2] No such file or directory: '/tmp/pywps_process_qjke6_af/sample/params/sample.rvic.prm.Columibia.20200824.nc'</ows:ExceptionText>\n  </ows:Exception>\n</ows:ExceptionReport>"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " owslib.wps.WPSException : {'code': 'NoApplicableCode', 'locator': 'None', 'text': 'Process failed, please check server error log'}\n"
      ]
     }
    ],
@@ -216,13 +205,13 @@
     "            \"GRIDID\":\"COLUMBIA\",\n",
     "        },\n",
     "        \"POUR_POINTS\":{\n",
-    "            \"FILE_NAME\":\"https://docker-dev03.pcic.uvic.ca/twitcher/ows/proxy/thredds/dodsC/datasets/RVIC/sample_pour.txt\"\n",
+    "            \"FILE_NAME\":\"tests/data/samples/sample_pour.txt\"\n",
     "        },\n",
     "        \"UH_BOX\":{\n",
-    "            \"FILE_NAME\":\"https://docker-dev03.pcic.uvic.ca/twitcher/ows/proxy/thredds/dodsC/datasets/RVIC/uhbox.csv\"\n",
+    "            \"FILE_NAME\":\"tests/data/samples/uhbox.csv\"\n",
     "        },\n",
     "        \"ROUTING\": {\n",
-    "            \"FILE_NAME\":\"https://docker-dev03.pcic.uvic.ca/twitcher/ows/proxy/thredds/dodsC/datasets/RVIC/sample_flow_parameters.nc\"\n",
+    "            \"FILE_NAME\":\"tests/data/samples/sample_flow_parameters.nc\"\n",
     "        },\n",
     "        \"DOMAIN\": {\n",
     "            \"FILE_NAME\":\"https://docker-dev03.pcic.uvic.ca/twitcher/ows/proxy/thredds/dodsC/datasets/RVIC/sample_routing_domain.nc\"\n",
@@ -236,7 +225,9 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "output.get()"
+   ]
   }
  ],
  "metadata": {

--- a/notebooks/demo_individual/demo_parameters.ipynb
+++ b/notebooks/demo_individual/demo_parameters.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -17,7 +17,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -28,7 +28,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -39,15 +39,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
        "\u001b[0;31mType:\u001b[0m            WPSClient\n",
-       "\u001b[0;31mString form:\u001b[0m     <birdy.client.base.WPSClient object at 0x7f07302baeb8>\n",
-       "\u001b[0;31mFile:\u001b[0m            ~/osprey-venv/lib/python3.6/site-packages/birdy/client/base.py\n",
+       "\u001b[0;31mString form:\u001b[0m     <birdy.client.base.WPSClient object at 0x7fc1e50f80f0>\n",
+       "\u001b[0;31mFile:\u001b[0m            ~/Desktop/osprey/venv/lib/python3.6/site-packages/birdy/client/base.py\n",
        "\u001b[0;31mDocstring:\u001b[0m      \n",
        "A Web Processing Service for Climate Data Analysis.\n",
        "\n",
@@ -96,7 +96,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -136,7 +136,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -154,7 +154,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -166,18 +166,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
        "parametersResponse(\n",
-       "    output='http://localhost:5002/outputs/c70edd66-e893-11ea-a870-c86000e3f2fd/sample.rvic.prm.COLUMBIA.20200827.nc'\n",
+       "    output='http://localhost:5002/outputs/c24ad282-f2d7-11ea-9093-c86000e3f36f/sample.rvic.prm.COLUMBIA.20200909.nc'\n",
        ")"
       ]
      },
-     "execution_count": 8,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -188,14 +188,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "/home/slim/osprey/tests/configs/parameter_mixed.cfg\n"
+      "/home/sangwonl/Desktop/osprey/tests/configs/parameter_mixed.cfg\n"
      ]
     }
    ],
@@ -207,7 +207,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -225,18 +225,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
        "parametersResponse(\n",
-       "    output='http://localhost:5002/outputs/ce1ee182-e893-11ea-a870-c86000e3f2fd/sample.rvic.prm.COLUMBIA.20200827.nc'\n",
+       "    output='http://localhost:5002/outputs/cf30040e-f2d7-11ea-9093-c86000e3f36f/sample.rvic.prm.COLUMBIA.20200909.nc'\n",
        ")"
       ]
      },
-     "execution_count": 12,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -250,14 +250,51 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "output = osprey.parameters(\n",
+    "    config = {\n",
+    "        \"OPTIONS\": {\"CASEID\": \"sample\", \"GRIDID\": \"COLUMBIA\",},\n",
+    "        \"POUR_POINTS\": {\n",
+    "            \"FILE_NAME\": resource_filename(__name__, \"tests/data/samples/sample_pour.txt\")\n",
+    "        },\n",
+    "        \"UH_BOX\": {\n",
+    "            \"FILE_NAME\": resource_filename(__name__, \"tests/data/samples/uhbox.csv\")\n",
+    "        },\n",
+    "        \"ROUTING\": {\n",
+    "            \"FILE_NAME\": resource_filename(\n",
+    "                __name__, \"tests/data/samples/sample_flow_parameters.nc\"\n",
+    "            )\n",
+    "        },\n",
+    "        \"DOMAIN\": {\n",
+    "            \"FILE_NAME\": resource_filename(\n",
+    "                __name__, \"tests/data/samples/sample_routing_domain.nc\"\n",
+    "            )\n",
+    "        }\n",
+    "    }\n",
+    ")"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
-   "source": []
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "parametersResponse(\n",
+       "    output='http://localhost:5002/outputs/6828fa26-f2d8-11ea-9093-c86000e3f36f/sample.rvic.prm.COLUMBIA.20200909.nc'\n",
+       ")"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "output.get()"
+   ]
   },
   {
    "cell_type": "code",

--- a/osprey/processes/wps_convolution.py
+++ b/osprey/processes/wps_convolution.py
@@ -129,7 +129,7 @@ class Convolution(Process):
             config = read_config(unprocessed)
         else:
             unprocessed = unprocessed.replace("'", '"')
-            config = config_hander(self.workdir, unprocessed, self.config_template)
+            config = config_hander(self.workdir, convolution.__name__, unprocessed, self.config_template)
 
         run_rvic(
             self.workdir, convolution, version, config,

--- a/osprey/processes/wps_convolution.py
+++ b/osprey/processes/wps_convolution.py
@@ -6,13 +6,14 @@ from rvic.convolution import convolution
 from rvic.core.config import read_config
 from rvic.version import version
 
-from wps_tools.utils import log_handler, collect_output_files
+from wps_tools.utils import log_handler
 from wps_tools.io import nc_output, log_level
 from osprey.utils import (
     logger,
     config_hander,
     config_file_builder,
     run_rvic,
+    get_outfile,
 )
 
 from datetime import datetime, timedelta
@@ -103,19 +104,6 @@ class Convolution(Process):
             status_supported=True,
         )
 
-    def get_outfile(self, config):
-        case_id = config["OPTIONS"]["CASEID"]
-        stop_date = config["OPTIONS"]["STOP_DATE"]
-        end_date = str(
-            datetime.strptime(stop_date, "%Y-%m-%d").date() + timedelta(days=1)
-        )
-
-        outdir = os.path.join(config["OPTIONS"]["CASE_DIR"], "hist")
-        filename = ".".join([case_id, "rvic", "h0a", end_date, "nc"])
-        (param_file,) = collect_output_files(filename, outdir)
-
-        return os.path.join(outdir, param_file)
-
     def _handler(self, request, response):
         loglevel = request.inputs["loglevel"][0].data
         log_handler(
@@ -157,7 +145,7 @@ class Convolution(Process):
             log_level=loglevel,
             process_step="build_output",
         )
-        response.outputs["output"].file = self.get_outfile(config)
+        response.outputs["output"].file = get_outfile(config, "hist")
 
         log_handler(
             self,

--- a/osprey/processes/wps_convolution.py
+++ b/osprey/processes/wps_convolution.py
@@ -127,16 +127,13 @@ class Convolution(Process):
 
         if os.path.isfile(unprocessed):
             config = read_config(unprocessed)
-            run_rvic(convolution, version, config, unprocessed)
         else:
             unprocessed = unprocessed.replace("'", '"')
             config = config_hander(self.workdir, unprocessed, self.config_template)
-            run_rvic(
-                convolution,
-                version,
-                config,
-                config_file_builder(self.workdir, config, self.config_template),
-            )
+
+        run_rvic(
+            self.workdir, convolution, version, config,
+        )
 
         log_handler(
             self,

--- a/osprey/processes/wps_convolution.py
+++ b/osprey/processes/wps_convolution.py
@@ -125,7 +125,6 @@ class Convolution(Process):
         if os.path.isfile(unprocessed):
             config = read_config(unprocessed)
         else:
-            unprocessed = unprocessed.replace("'", '"')
             config = config_hander(
                 self.workdir, convolution.__name__, unprocessed, self.config_template
             )

--- a/osprey/processes/wps_convolution.py
+++ b/osprey/processes/wps_convolution.py
@@ -11,8 +11,6 @@ from wps_tools.io import nc_output, log_level
 from osprey.utils import (
     logger,
     config_hander,
-    config_file_builder,
-    run_rvic,
     get_outfile,
 )
 
@@ -133,9 +131,7 @@ class Convolution(Process):
                 self.workdir, convolution.__name__, unprocessed, self.config_template
             )
 
-        run_rvic(
-            self.workdir, convolution, version, config,
-        )
+        convolution(config)
 
         log_handler(
             self,

--- a/osprey/processes/wps_convolution.py
+++ b/osprey/processes/wps_convolution.py
@@ -68,7 +68,7 @@ class Convolution(Process):
                 "DATL_FILE": None,
                 "TIME_VAR": "time",
                 "LATITUDE_VAR": "lat",
-                "DATL_LIQ_FLDS": "RUNOFF, BASEFLOW",
+                "DATL_LIQ_FLDS": ["RUNOFF", "BASEFLOW"],
                 "START": None,
                 "END": None,
             },

--- a/osprey/processes/wps_convolution.py
+++ b/osprey/processes/wps_convolution.py
@@ -4,7 +4,6 @@ from pywps.app.exceptions import ProcessError
 
 from rvic.convolution import convolution
 from rvic.core.config import read_config
-from rvic.version import version
 
 from wps_tools.utils import log_handler
 from wps_tools.io import nc_output, log_level

--- a/osprey/processes/wps_parameters.py
+++ b/osprey/processes/wps_parameters.py
@@ -17,7 +17,12 @@ from wps_tools.io import (
     log_level,
     nc_output,
 )
-from osprey.utils import logger
+from osprey.utils import (
+    logger,
+    run_rvic,
+    config_hander,
+    config_file_builder,
+)
 
 # Library imports
 import os

--- a/osprey/processes/wps_parameters.py
+++ b/osprey/processes/wps_parameters.py
@@ -6,7 +6,7 @@ from pywps import (
 from pywps.app.Common import Metadata
 
 # Tool imports
-from rvic import version
+from rvic.version import version
 from rvic.parameters import parameters
 from rvic.core.config import read_config
 from wps_tools.utils import (
@@ -143,7 +143,7 @@ class Parameters(Process):
 
     def _handler(self, request, response):
         if request.inputs["version"][0].data:
-            logger.info(version.short_version)
+            logger.info(version)
 
         (unprocessed, np, loglevel) = self.collect_args(request)
         log_handler(
@@ -168,7 +168,9 @@ class Parameters(Process):
             config = read_config(unprocessed)
         else:
             unprocessed = unprocessed.replace("'", '"')
-            config = config_hander(self.workdir, unprocessed, self.config_template)
+            config = config_hander(
+                self.workdir, parameters.__name__, unprocessed, self.config_template
+            )
 
         run_rvic(
             self.workdir, parameters, version, config,

--- a/osprey/processes/wps_parameters.py
+++ b/osprey/processes/wps_parameters.py
@@ -157,7 +157,6 @@ class Parameters(Process):
         if os.path.isfile(unprocessed):
             config = read_config(unprocessed)
         else:
-            unprocessed = unprocessed.replace("'", '"')
             config = config_hander(
                 self.workdir, parameters.__name__, unprocessed, self.config_template
             )

--- a/osprey/processes/wps_parameters.py
+++ b/osprey/processes/wps_parameters.py
@@ -55,7 +55,7 @@ class Parameters(Process):
                 "SEARCH_FOR_CHANNEL": False,
             },
             "POUR_POINTS": {"FILE_NAME": None,},
-            "UH_BOX": {"FILE_NAME": None,},
+            "UH_BOX": {"FILE_NAME": None, "HEADER_LINES": 1,},
             "ROUTING": {
                 "FILE_NAME": None,
                 "LONGITUDE_VAR": "lon",

--- a/osprey/processes/wps_parameters.py
+++ b/osprey/processes/wps_parameters.py
@@ -138,7 +138,7 @@ class Parameters(Process):
             logger.info(version)
 
         (unprocessed, np, loglevel) = self.collect_args(request)
-        
+
         log_handler(
             self,
             response,

--- a/osprey/processes/wps_parameters.py
+++ b/osprey/processes/wps_parameters.py
@@ -16,9 +16,7 @@ from wps_tools.io import (
 )
 from osprey.utils import (
     logger,
-    run_rvic,
     config_hander,
-    config_file_builder,
     get_outfile,
 )
 
@@ -164,9 +162,7 @@ class Parameters(Process):
                 self.workdir, parameters.__name__, unprocessed, self.config_template
             )
 
-        run_rvic(
-            self.workdir, parameters, version, config,
-        )
+        parameters(config, np)
 
         log_handler(
             self,

--- a/osprey/processes/wps_parameters.py
+++ b/osprey/processes/wps_parameters.py
@@ -166,16 +166,13 @@ class Parameters(Process):
 
         if os.path.isfile(unprocessed):
             config = read_config(unprocessed)
-            run_rvic(parameters, version, config, unprocessed)
         else:
             unprocessed = unprocessed.replace("'", '"')
             config = config_hander(self.workdir, unprocessed, self.config_template)
-            run_rvic(
-                parameters,
-                version,
-                config,
-                config_file_builder(self.workdir, config, self.config_template),
-            )
+
+        run_rvic(
+            self.workdir, parameters, version, config,
+        )
 
         log_handler(
             self,

--- a/osprey/processes/wps_parameters.py
+++ b/osprey/processes/wps_parameters.py
@@ -27,6 +27,58 @@ from datetime import datetime
 
 class Parameters(Process):
     def __init__(self):
+        self.config_template = {
+            # configuration dictionary used for RVIC parameters
+            # required user inputs are defined as None value
+            "OPTIONS": {
+                "LOG_LEVEL": "INFO",
+                "VERBOSE": True,
+                "CLEAN": False,
+                "CASEID": None,
+                "GRIDID": None,
+                "CASE_DIR": None,
+                "TEMP_DIR": None,
+                "REMAP": False,
+                "AGGREGATE": False,
+                "AGG_PAD": 25,
+                "NETCDF_FORMAT": "NETCDF4",
+                "NETCDF_ZLIB": False,
+                "NETCDF_COMPLEVEL": 4,
+                "NETCDF_SIGFIGS": None,
+                "SUBSET_DAYS": None,
+                "CONSTRAIN_FRACTIONS": False,
+                "SEARCH_FOR_CHANNEL": False,
+            },
+            "POUR_POINTS": {
+                "FILE_NAME": None,
+            },
+            "UH_BOX": {
+                "FILE_NAME": None,
+            },
+            "ROUTING": {
+                "FILE_NAME": None,
+                "LONGITUDE_VAR": "lon",
+                "LATITUDE_VAR": "lat",
+                "FLOW_DISTANCE_VAR": "Flow_Distance",
+                "FLOW_DIRECTION_VAR": "Flow_Direction",
+                "BASIN_ID_VAR": "Basin_ID",
+                "VELOCITY": "velocity",
+                "DIFFUSION": "diffusion",
+                "VELOCITY": 1,
+                "DIFFUSION": 2000,
+                "OUTPUT_INTERVAL": 86400,
+                "BASIN_FLOWDAYS": 100,
+                "CELL_FLOWDAYS": 4,
+            },
+            "DOMAIN": {
+                "FILE_NAME": None,
+                "LONGITUDE_VAR": "lon"
+                "LATITUDE_VAR": "lat"
+                "LAND_MASK_VAR": "mask"
+                "FRACTION_VAR": "frac"
+                "AREA_VAR": "area"
+            },
+        }
         self.status_percentage_steps = {
             "start": 0,
             "process": 10,

--- a/osprey/processes/wps_parameters.py
+++ b/osprey/processes/wps_parameters.py
@@ -9,10 +9,7 @@ from pywps.app.Common import Metadata
 from rvic.version import version
 from rvic.parameters import parameters
 from rvic.core.config import read_config
-from wps_tools.utils import (
-    collect_output_files,
-    log_handler,
-)
+from wps_tools.utils import log_handler
 from wps_tools.io import (
     log_level,
     nc_output,
@@ -22,6 +19,7 @@ from osprey.utils import (
     run_rvic,
     config_hander,
     config_file_builder,
+    get_outfile,
 )
 
 # Library imports
@@ -135,12 +133,6 @@ class Parameters(Process):
         loglevel = request.inputs["loglevel"][0].data
         return (unprocessed, np, loglevel)
 
-    def get_outfile(self, config):
-        outdir = os.path.join(config["OPTIONS"]["CASE_DIR"], "params")
-        date = datetime.now().strftime("%Y%m%d")
-        (param_file,) = collect_output_files(date, outdir)
-        return os.path.join(outdir, param_file)
-
     def _handler(self, request, response):
         if request.inputs["version"][0].data:
             logger.info(version)
@@ -184,7 +176,7 @@ class Parameters(Process):
             log_level=loglevel,
             process_step="build_output",
         )
-        response.outputs["output"].file = self.get_outfile(config)
+        response.outputs["output"].file = get_outfile(config, "params")
 
         log_handler(
             self,

--- a/osprey/processes/wps_parameters.py
+++ b/osprey/processes/wps_parameters.py
@@ -49,12 +49,8 @@ class Parameters(Process):
                 "CONSTRAIN_FRACTIONS": False,
                 "SEARCH_FOR_CHANNEL": False,
             },
-            "POUR_POINTS": {
-                "FILE_NAME": None,
-            },
-            "UH_BOX": {
-                "FILE_NAME": None,
-            },
+            "POUR_POINTS": {"FILE_NAME": None,},
+            "UH_BOX": {"FILE_NAME": None,},
             "ROUTING": {
                 "FILE_NAME": None,
                 "LONGITUDE_VAR": "lon",
@@ -72,11 +68,11 @@ class Parameters(Process):
             },
             "DOMAIN": {
                 "FILE_NAME": None,
-                "LONGITUDE_VAR": "lon"
-                "LATITUDE_VAR": "lat"
-                "LAND_MASK_VAR": "mask"
-                "FRACTION_VAR": "frac"
-                "AREA_VAR": "area"
+                "LONGITUDE_VAR": "lon",
+                "LATITUDE_VAR": "lat",
+                "LAND_MASK_VAR": "mask",
+                "FRACTION_VAR": "frac",
+                "AREA_VAR": "area",
             },
         }
         self.status_percentage_steps = {

--- a/osprey/processes/wps_parameters.py
+++ b/osprey/processes/wps_parameters.py
@@ -138,7 +138,7 @@ class Parameters(Process):
             logger.info(version)
 
         (unprocessed, np, loglevel) = self.collect_args(request)
-        replace_urls(config, self.workdir)
+        
         log_handler(
             self,
             response,
@@ -158,6 +158,7 @@ class Parameters(Process):
         )
 
         if os.path.isfile(unprocessed):
+            replace_urls(unprocessed, self.workdir)
             config = read_config(unprocessed)
         else:
             config = config_hander(

--- a/osprey/utils.py
+++ b/osprey/utils.py
@@ -4,6 +4,7 @@ import logging
 import os
 import json
 from datetime import datetime, timedelta
+from collections.abc import Iterable
 
 logger = logging.getLogger("PYWPS")
 logger.setLevel(logging.NOTSET)
@@ -79,7 +80,12 @@ def config_file_builder(workdir, config):
         for upper_key in config.keys():
             cfg_file.write(f"[{upper_key}]\n")
             for k, v in config[upper_key].items():
-                cfg_file.write(f"{k}: {str(v)}\n")
+                if isinstance(v, Iterable) and type(v) != str:
+                    v_string = ", ".join(v)
+                else:
+                    v_string = str(v)
+                cfg_file.write(f"{k}: {v_string}\n")
+
     return cfg_filepath
 
 

--- a/osprey/utils.py
+++ b/osprey/utils.py
@@ -89,16 +89,6 @@ def config_file_builder(workdir, config):
     return cfg_filepath
 
 
-def build_output(config):
-    case_id = config["OPTIONS"]["CASEID"]
-    stop_date = config["OPTIONS"]["STOP_DATE"]
-    end_date = str(datetime.strptime(stop_date, "%Y-%m-%d").date() + timedelta(days=1))
-
-    directory = os.path.join(config["OPTIONS"]["CASE_DIR"], "hist")
-    filename = ".".join([case_id, "rvic", "h0a", end_date, "nc"])
-    return os.path.join(directory, filename)
-
-
 def run_rvic(workdir, rvic_module, version, config):
     if version == "1.1.0-1":  # RVIC1.1.0.post1
         cfg_filepath = config_file_builder(workdir, config)

--- a/osprey/utils.py
+++ b/osprey/utils.py
@@ -69,18 +69,19 @@ def config_hander(workdir, unprocessed, config_template):
         raise ProcessError("Invalid config key provided")
 
 
-def config_file_builder(workdir, config, config_template):
+def config_file_builder(workdir, config):
     """
     This function is used for RVIC1.1.0.post1 only since the version requires Configuration input
     to be a .cfg filepath. The function uses information from config to create the file.
     """
     cfg_filepath = os.path.join(workdir, "convolve_file.cfg")
     with open(cfg_filepath, "w") as cfg_file:
-        for upper_key in config_template.keys():
+        for upper_key in config.keys():
             cfg_file.write(f"[{upper_key}]\n")
-            for k, v in config_template[upper_key].items():
+            for k, v in config[upper_key].items():
                 cfg_file.write(f"{k}: {str(v)}\n")
 
+    logger.critical(cfg_filepath)
     return cfg_filepath
 
 
@@ -94,9 +95,9 @@ def build_output(config):
     return os.path.join(directory, filename)
 
 
-def run_rvic(rvic_module, version, config, config_file):
+def run_rvic(workdir, rvic_module, version, config):
     if version == "1.1.0-1":  # RVIC1.1.0.post1
-        cfg_filepath = config_file
+        cfg_filepath = config_file_builder(workdir, config)
         rvic_module(cfg_filepath)
     elif version == "1.1.1":  # RVIC1.1.1
         rvic_module(config)

--- a/osprey/utils.py
+++ b/osprey/utils.py
@@ -71,33 +71,6 @@ def config_hander(workdir, modulue_name, unprocessed, config_template):
         raise ProcessError("Invalid config key provided")
 
 
-def config_file_builder(workdir, config):
-    """
-    This function is used for RVIC1.1.0.post1 only since the version requires Configuration input
-    to be a .cfg filepath. The function uses information from config to create the file.
-    """
-    cfg_filepath = os.path.join(workdir, "convolve_file.cfg")
-    with open(cfg_filepath, "w") as cfg_file:
-        for upper_key in config.keys():
-            cfg_file.write(f"[{upper_key}]\n")
-            for k, v in config[upper_key].items():
-                if isinstance(v, Iterable) and type(v) != str:
-                    v_string = ", ".join(v)
-                else:
-                    v_string = str(v)
-                cfg_file.write(f"{k}: {v_string}\n")
-
-    return cfg_filepath
-
-
-def run_rvic(workdir, rvic_module, version, config):
-    if version == "1.1.0-1":  # RVIC1.1.0.post1
-        cfg_filepath = config_file_builder(workdir, config)
-        rvic_module(cfg_filepath)
-    elif version == "1.1.1":  # RVIC1.1.1
-        rvic_module(config)
-
-
 def get_outfile(config, dir_name):
     case_id = config["OPTIONS"]["CASEID"]
     case_dir = config["OPTIONS"]["CASE_DIR"]

--- a/osprey/utils.py
+++ b/osprey/utils.py
@@ -72,6 +72,16 @@ def config_hander(workdir, modulue_name, unprocessed, config_template):
 
 
 def get_outfile(config, dir_name):
+    """
+    This function returns the output filepath of RVIC processes.
+    Parameters
+        1. config (dict)h: Set of key-value pairs that contains the information of filename
+            parameters file: CASEID.rvic.prm.GRIDID.DATE.nc
+            convolution file: CASEID.rvic.h0a.ENDINGDATE.nc
+        2. dir_name (str): name of the directory that te output file will be stored.
+            parameters module   --->    dir_name == "params"
+            convoltion module   --->    dir_name == "hist"
+    """
     case_id = config["OPTIONS"]["CASEID"]
     case_dir = config["OPTIONS"]["CASE_DIR"]
     if dir_name == "params":

--- a/osprey/utils.py
+++ b/osprey/utils.py
@@ -42,7 +42,7 @@ def config_hander(workdir, modulue_name, unprocessed, config_template):
     If CASE_DIR and REST_DATE are not provided from a user, their values are derived from
     CASEID and STOP_DATE by default.
     """
-    unprocessed = json.loads(unprocessed)
+    unprocessed = eval(unprocessed)
     try:
         for upper_key in unprocessed.keys():
             for lower_key in unprocessed[upper_key].keys():

--- a/osprey/utils.py
+++ b/osprey/utils.py
@@ -5,6 +5,7 @@ import os
 import json
 from datetime import datetime, timedelta
 from collections.abc import Iterable
+from wps_tools.utils import collect_output_files
 
 logger = logging.getLogger("PYWPS")
 logger.setLevel(logging.NOTSET)
@@ -97,7 +98,7 @@ def run_rvic(workdir, rvic_module, version, config):
         rvic_module(config)
 
 
-def get_outfile(self, dir_name):
+def get_outfile(config, dir_name):
     case_id = config["OPTIONS"]["CASEID"]
     case_dir = config["OPTIONS"]["CASE_DIR"]
     if dir_name == "params":
@@ -114,5 +115,5 @@ def get_outfile(self, dir_name):
 
     outdir = os.path.join(case_dir, dir_name)
     (out_file,) = collect_output_files(filename, outdir)
-    
+
     return os.path.join(outdir, out_file)

--- a/osprey/utils.py
+++ b/osprey/utils.py
@@ -34,7 +34,7 @@ def replace_filenames(config, temp_config):
     temp_config.writelines(newdata)
 
 
-def config_hander(workdir, unprocessed, config_template):
+def config_hander(workdir, modulue_name, unprocessed, config_template):
     """
     This function enables users to provide dictionary-like string for Configuration input.
     If CASE_DIR and REST_DATE are not provided from a user, their values are derived from
@@ -52,12 +52,12 @@ def config_hander(workdir, unprocessed, config_template):
             config_template["OPTIONS"]["CASE_DIR"] = os.path.join(
                 workdir, config_template["OPTIONS"]["CASEID"]
             )
-        try:
+        if modulue_name == "convolution":
             if config_template["OPTIONS"]["REST_DATE"] == None:
                 config_template["OPTIONS"]["REST_DATE"] = config_template["OPTIONS"][
                     "STOP_DATE"
                 ]
-        except KeyError:
+        elif modulue_name == "parameters":
             if config_template["OPTIONS"]["TEMP_DIR"] == None:
                 config_template["OPTIONS"]["TEMP_DIR"] = (
                     config_template["OPTIONS"]["CASEID"] + "/temp"
@@ -80,8 +80,6 @@ def config_file_builder(workdir, config):
             cfg_file.write(f"[{upper_key}]\n")
             for k, v in config[upper_key].items():
                 cfg_file.write(f"{k}: {str(v)}\n")
-
-    logger.critical(cfg_filepath)
     return cfg_filepath
 
 

--- a/osprey/utils.py
+++ b/osprey/utils.py
@@ -52,10 +52,16 @@ def config_hander(workdir, unprocessed, config_template):
             config_template["OPTIONS"]["CASE_DIR"] = os.path.join(
                 workdir, config_template["OPTIONS"]["CASEID"]
             )
-        if config_template["OPTIONS"]["REST_DATE"] == None:
-            config_template["OPTIONS"]["REST_DATE"] = config_template["OPTIONS"][
-                "STOP_DATE"
-            ]
+        try:
+            if config_template["OPTIONS"]["REST_DATE"] == None:
+                config_template["OPTIONS"]["REST_DATE"] = config_template["OPTIONS"][
+                    "STOP_DATE"
+                ]
+        except KeyError:
+            if config_template["OPTIONS"]["TEMP_DIR"] == None:
+                config_template["OPTIONS"]["TEMP_DIR"] = (
+                    config_template["OPTIONS"]["CASEID"] + "/temp"
+                )
 
         return config_template
 

--- a/osprey/utils.py
+++ b/osprey/utils.py
@@ -95,3 +95,24 @@ def run_rvic(workdir, rvic_module, version, config):
         rvic_module(cfg_filepath)
     elif version == "1.1.1":  # RVIC1.1.1
         rvic_module(config)
+
+
+def get_outfile(self, dir_name):
+    case_id = config["OPTIONS"]["CASEID"]
+    case_dir = config["OPTIONS"]["CASE_DIR"]
+    if dir_name == "params":
+        grid_id = config["OPTIONS"]["GRIDID"]
+        date = datetime.now().strftime("%Y%m%d")
+        filename = ".".join([case_id, "rvic", "prm", grid_id, date, "nc"])
+
+    elif dir_name == "hist":
+        stop_date = config["OPTIONS"]["STOP_DATE"]
+        end_date = str(
+            datetime.strptime(stop_date, "%Y-%m-%d").date() + timedelta(days=1)
+        )
+        filename = ".".join([case_id, "rvic", "h0a", end_date, "nc"])
+
+    outdir = os.path.join(case_dir, dir_name)
+    (out_file,) = collect_output_files(filename, outdir)
+    
+    return os.path.join(outdir, out_file)

--- a/osprey/utils.py
+++ b/osprey/utils.py
@@ -106,7 +106,7 @@ def get_outfile(config, dir_name):
     """
     This function returns the output filepath of RVIC processes.
     Parameters
-        1. config (dict)h: Set of key-value pairs that contains the information of filename
+        1. config (dict): Set of key-value pairs that contains the information of filename
             parameters file: CASEID.rvic.prm.GRIDID.DATE.nc
             convolution file: CASEID.rvic.h0a.ENDINGDATE.nc
         2. dir_name (str): name of the directory that te output file will be stored.

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ pywps>=4.2
 jinja2
 click
 psutil
-rvic==1.1.0post1
+rvic==1.1.1
 nchelpers==5.5.7
 wps-tools==0.1.2

--- a/tests/test_wps_parameters.py
+++ b/tests/test_wps_parameters.py
@@ -10,14 +10,39 @@ from osprey.utils import replace_filenames
 
 @pytest.mark.parametrize(
     ("config"),
-    [resource_filename(__name__, "data/samples/sample_parameter_config.cfg")],
+    [
+        resource_filename(__name__, "data/samples/sample_parameter_config.cfg"),
+        {
+            "OPTIONS": {"CASEID": "sample", "GRIDID": "COLUMBIA",},
+            "POUR_POINTS": {
+                "FILE_NAME": resource_filename(__name__, "data/samples/sample_pour.txt")
+            },
+            "UH_BOX": {
+                "FILE_NAME": resource_filename(__name__, "data/samples/uhbox.csv")
+            },
+            "ROUTING": {
+                "FILE_NAME": resource_filename(
+                    __name__, "data/samples/sample_flow_parameters.nc"
+                )
+            },
+            "DOMAIN": {
+                "FILE_NAME": resource_filename(
+                    __name__, "data/samples/sample_routing_domain.nc"
+                )
+            },
+        },
+    ],
 )
 def test_parameters_local(config):
-    config_name = os.path.splitext(config)[0]  # Remove .cfg extension
-    with NamedTemporaryFile(
-        suffix=".cfg", prefix=os.path.basename(config_name), mode="w+t"
-    ) as temp_config:
-        replace_filenames(config, temp_config)
-        temp_config.read()
-        params = f"config={temp_config.name};"
+    if type(config) == dict:
+        params = ("config={0};").format(config)
         run_wps_process(Parameters(), params)
+    else:
+        config_name = os.path.splitext(config)[0]  # Remove .cfg extension
+        with NamedTemporaryFile(
+            suffix=".cfg", prefix=os.path.basename(config_name), mode="w+t"
+        ) as temp_config:
+            replace_filenames(config, temp_config)
+            temp_config.read()
+            params = f"config={temp_config.name};"
+            run_wps_process(Parameters(), params)


### PR DESCRIPTION
This PR resolves #23 

Currently, `RVIC parameters` module only allows inputs through pre-generated `.cfg` file. It degrades usability of the software. Therefore, dictionary inputs are allowed by `osprey/wps_parameters` and processed into `.cfg` files. Default values are set for many of the parameters (keys) referring to [Lee's note](https://pcic.uvic.ca/confluence/pages/viewpage.action?spaceKey=CSG&title=Meeting+Notes+2018-05-09+-+RVIC+demo) in confluence.

Example dictionary inputs are added to both `jupyter lab` demo and `test_wps_parameters`