### PR TITLE
A single process that runs both wps_parameters and wps_convolution processes 

### DIFF
--- a/notebooks/demo_individual/demo_convolution.ipynb
+++ b/notebooks/demo_individual/demo_convolution.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -14,7 +14,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -25,7 +25,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -36,77 +36,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "\u001b[0;31mType:\u001b[0m            WPSClient\n",
-       "\u001b[0;31mString form:\u001b[0m     <birdy.client.base.WPSClient object at 0x7f4e00506a20>\n",
-       "\u001b[0;31mFile:\u001b[0m            ~/Desktop/osprey/venv/lib/python3.6/site-packages/birdy/client/base.py\n",
-       "\u001b[0;31mDocstring:\u001b[0m      \n",
-       "A Web Processing Service for Climate Data Analysis.\n",
-       "\n",
-       "Processes\n",
-       "---------\n",
-       "\n",
-       "convolution\n",
-       "    Aggregates the flow contribution from all upstream grid cellsat every timestep lagged according the Impuls Response Functions.\n",
-       "\n",
-       "parameters\n",
-       "    Develop impulse response functions using inputs from a configuration file or dictionary\n",
-       "\u001b[0;31mClass docstring:\u001b[0m\n",
-       "Returns a class where every public method is a WPS process available at\n",
-       "the given url.\n",
-       "\n",
-       "Example:\n",
-       "    >>> emu = WPSClient(url='<server url>')\n",
-       "    >>> emu.hello('stranger')\n",
-       "    'Hello stranger'\n",
-       "\u001b[0;31mInit docstring:\u001b[0m \n",
-       "Args:\n",
-       "    url (str): Link to WPS provider. config (Config): an instance\n",
-       "    processes: Specify a subset of processes to bind. Defaults to all\n",
-       "        processes.\n",
-       "    converters (dict): Correspondence of {mimetype: class} to convert\n",
-       "        this mimetype to a python object.\n",
-       "    username (str): passed to :class:`owslib.wps.WebProcessingService`\n",
-       "    password (str): passed to :class:`owslib.wps.WebProcessingService`\n",
-       "    headers (str): passed to :class:`owslib.wps.WebProcessingService`\n",
-       "    auth (requests.auth.AuthBase): requests-style auth class to authenticate,\n",
-       "        see https://2.python-requests.org/en/master/user/authentication/\n",
-       "    verify (bool): passed to :class:`owslib.wps.WebProcessingService`\n",
-       "    cert (str): passed to :class:`owslib.wps.WebProcessingService`\n",
-       "    verbose (str): passed to :class:`owslib.wps.WebProcessingService`\n",
-       "    progress (bool): If True, enable interactive user mode.\n",
-       "    version (str): WPS version to use.\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "# Check wps info\n",
-    "osprey?"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "\u001b[0;31mSignature:\u001b[0m \u001b[0mosprey\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mconvolution\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mconfig\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mloglevel\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m'INFO'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+       "\u001b[0;31mSignature:\u001b[0m \u001b[0mosprey\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mconvolution\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mconvolve_config\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mloglevel\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m'INFO'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
        "\u001b[0;31mDocstring:\u001b[0m\n",
        "Aggregates the flow contribution from all upstream grid cellsat every timestep lagged according the Impuls Response Functions.\n",
        "\n",
        "Parameters\n",
        "----------\n",
-       "config : string\n",
+       "convolve_config : string\n",
        "    Path to input configuration file or input dictionary\n",
        "loglevel : {'CRITICAL', 'ERROR', 'WARNING', 'INFO', 'DEBUG', 'NOTSET'}string\n",
        "    Logging level\n",
@@ -130,7 +72,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -148,30 +90,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "# generate convolution\n",
     "output = osprey.convolution(\n",
-    "    config = cfg_file\n",
+    "    convolve_config = cfg_file\n",
     ")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
        "convolutionResponse(\n",
-       "    output='http://localhost:5002/outputs/951bc6ec-e713-11ea-a3bb-c86000e3f36f/sample.rvic.h0a.2013-01-01.nc'\n",
+       "    output='http://localhost:5002/outputs/b2fab4d0-e8ac-11ea-94ae-c86000e3f36f/sample.rvic.h0a.2013-01-01.nc'\n",
        ")"
       ]
      },
-     "execution_count": 8,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -182,13 +124,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "# generate convolution\n",
+    "# dictionary input\n",
     "output = osprey.convolution(\n",
-    "    config = {\n",
+    "    convolve_config = {\n",
     "        \"OPTIONS\":{\n",
     "            \"CASEID\":\"sample\", \n",
     "            \"RUN_STARTDATE\": \"2012-12-01-00\", \n",
@@ -211,18 +153,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
        "convolutionResponse(\n",
-       "    output='http://localhost:5002/outputs/a602bbb4-e713-11ea-a3bb-c86000e3f36f/sample.rvic.h0a.2013-01-01.nc'\n",
+       "    output='http://localhost:5002/outputs/b9b3e6d4-e8ac-11ea-94ae-c86000e3f36f/sample.rvic.h0a.2013-01-01.nc'\n",
        ")"
       ]
      },
-     "execution_count": 10,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/notebooks/demo_individual/demo_full_rvic.ipynb
+++ b/notebooks/demo_individual/demo_full_rvic.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -14,7 +14,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -25,7 +25,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -36,14 +36,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
        "\u001b[0;31mType:\u001b[0m            WPSClient\n",
-       "\u001b[0;31mString form:\u001b[0m     <birdy.client.base.WPSClient object at 0x7f2cc12a2780>\n",
+       "\u001b[0;31mString form:\u001b[0m     <birdy.client.base.WPSClient object at 0x7f2cab20d5c0>\n",
        "\u001b[0;31mFile:\u001b[0m            ~/Desktop/osprey/venv/lib/python3.6/site-packages/birdy/client/base.py\n",
        "\u001b[0;31mDocstring:\u001b[0m      \n",
        "A Web Processing Service for Climate Data Analysis.\n",
@@ -56,6 +56,9 @@
        "\n",
        "parameters\n",
        "    Develop impulse response functions using inputs from a configuration file or dictionary\n",
+       "\n",
+       "full_rvic\n",
+       "    Run full RVIC process combining Parameters and Convolution modules\n",
        "\u001b[0;31mClass docstring:\u001b[0m\n",
        "Returns a class where every public method is a WPS process available at\n",
        "the given url.\n",
@@ -93,20 +96,75 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "\u001b[0;31mSignature:\u001b[0m \u001b[0mosprey\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mfull_rvic\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mparams_config\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mconvolve_config\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mnp\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;36m1\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mloglevel\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m'INFO'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+       "\u001b[0;31mDocstring:\u001b[0m\n",
+       "Run full RVIC process combining Parameters and Convolution modules\n",
+       "\n",
+       "Parameters\n",
+       "----------\n",
+       "params_config : string\n",
+       "    Path to parameters module's input configuration file or input dictionary\n",
+       "convolve_config : string\n",
+       "    Path to convolution module's input configuration file or input dictionary\n",
+       "np : integer\n",
+       "    Number of processors used to run job\n",
+       "loglevel : {'CRITICAL', 'ERROR', 'WARNING', 'INFO', 'DEBUG', 'NOTSET'}string\n",
+       "    Logging level\n",
+       "\n",
+       "Returns\n",
+       "-------\n",
+       "output : ComplexData:mimetype:`application/x-netcdf`\n",
+       "    Output Netcdf File\n",
+       "\u001b[0;31mFile:\u001b[0m      ~/Desktop/osprey/</home/sangwonl/Desktop/osprey/venv/lib/python3.6/site-packages/birdy/client/base.py-4>\n",
+       "\u001b[0;31mType:\u001b[0m      method\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Check info on `full_rvic` process\n",
+    "osprey.full_rvic?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Object `osprey.full_rvic` not found.\n"
+      "/home/sangwonl/Desktop/osprey/tests/data/samples/sample_parameter_config.cfg\n"
      ]
     }
    ],
    "source": [
-    "# Check info on `parameters` process\n",
-    "osprey.full_rvic?"
+    "params_cfg = resource_filename(\"tests\", \"data/samples/sample_parameter_config.cfg\")\n",
+    "convolve_cfg = resource_filename(\"tests\", \"configs/convolve_opendap.cfg\")\n",
+    "\n",
+    "print(params_cfg)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# run parameters\n",
+    "output = osprey.full_rvic(\n",
+    "    params_config = params_cfg,\n",
+    "    convolve_config = convolve_cfg,\n",
+    ")"
    ]
   },
   {

--- a/notebooks/demo_individual/demo_full_rvic.ipynb
+++ b/notebooks/demo_individual/demo_full_rvic.ipynb
@@ -42,67 +42,14 @@
     {
      "data": {
       "text/plain": [
-       "\u001b[0;31mType:\u001b[0m            WPSClient\n",
-       "\u001b[0;31mString form:\u001b[0m     <birdy.client.base.WPSClient object at 0x7f2cab20d5c0>\n",
-       "\u001b[0;31mFile:\u001b[0m            ~/Desktop/osprey/venv/lib/python3.6/site-packages/birdy/client/base.py\n",
-       "\u001b[0;31mDocstring:\u001b[0m      \n",
-       "A Web Processing Service for Climate Data Analysis.\n",
-       "\n",
-       "Processes\n",
-       "---------\n",
-       "\n",
-       "convolution\n",
-       "    Aggregates the flow contribution from all upstream grid cellsat every timestep lagged according the Impuls Response Functions.\n",
-       "\n",
-       "parameters\n",
-       "    Develop impulse response functions using inputs from a configuration file or dictionary\n",
-       "\n",
-       "full_rvic\n",
-       "    Run full RVIC process combining Parameters and Convolution modules\n",
-       "\u001b[0;31mClass docstring:\u001b[0m\n",
-       "Returns a class where every public method is a WPS process available at\n",
-       "the given url.\n",
-       "\n",
-       "Example:\n",
-       "    >>> emu = WPSClient(url='<server url>')\n",
-       "    >>> emu.hello('stranger')\n",
-       "    'Hello stranger'\n",
-       "\u001b[0;31mInit docstring:\u001b[0m \n",
-       "Args:\n",
-       "    url (str): Link to WPS provider. config (Config): an instance\n",
-       "    processes: Specify a subset of processes to bind. Defaults to all\n",
-       "        processes.\n",
-       "    converters (dict): Correspondence of {mimetype: class} to convert\n",
-       "        this mimetype to a python object.\n",
-       "    username (str): passed to :class:`owslib.wps.WebProcessingService`\n",
-       "    password (str): passed to :class:`owslib.wps.WebProcessingService`\n",
-       "    headers (str): passed to :class:`owslib.wps.WebProcessingService`\n",
-       "    auth (requests.auth.AuthBase): requests-style auth class to authenticate,\n",
-       "        see https://2.python-requests.org/en/master/user/authentication/\n",
-       "    verify (bool): passed to :class:`owslib.wps.WebProcessingService`\n",
-       "    cert (str): passed to :class:`owslib.wps.WebProcessingService`\n",
-       "    verbose (str): passed to :class:`owslib.wps.WebProcessingService`\n",
-       "    progress (bool): If True, enable interactive user mode.\n",
-       "    version (str): WPS version to use.\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "osprey?"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "\u001b[0;31mSignature:\u001b[0m \u001b[0mosprey\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mfull_rvic\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mparams_config\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mconvolve_config\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mnp\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;36m1\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mloglevel\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m'INFO'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+       "\u001b[0;31mSignature:\u001b[0m\n",
+       "\u001b[0mosprey\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mfull_rvic\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m    \u001b[0mparams_config\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m    \u001b[0mconvolve_config\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m    \u001b[0mversion\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mTrue\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m    \u001b[0mnp\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;36m1\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m    \u001b[0mloglevel\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m'INFO'\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
        "\u001b[0;31mDocstring:\u001b[0m\n",
        "Run full RVIC process combining Parameters and Convolution modules\n",
        "\n",
@@ -112,6 +59,8 @@
        "    Path to parameters module's input configuration file or input dictionary\n",
        "convolve_config : string\n",
        "    Path to convolution module's input configuration file or input dictionary\n",
+       "version : boolean\n",
+       "    Return RVIC version string\n",
        "np : integer\n",
        "    Number of processors used to run job\n",
        "loglevel : {'CRITICAL', 'ERROR', 'WARNING', 'INFO', 'DEBUG', 'NOTSET'}string\n",
@@ -121,7 +70,7 @@
        "-------\n",
        "output : ComplexData:mimetype:`application/x-netcdf`\n",
        "    Output Netcdf File\n",
-       "\u001b[0;31mFile:\u001b[0m      ~/Desktop/osprey/</home/sangwonl/Desktop/osprey/venv/lib/python3.6/site-packages/birdy/client/base.py-4>\n",
+       "\u001b[0;31mFile:\u001b[0m      ~/Desktop/osprey/</home/sangwonl/Desktop/osprey/venv/lib/python3.6/site-packages/birdy/client/base.py-14>\n",
        "\u001b[0;31mType:\u001b[0m      method\n"
       ]
      },
@@ -160,10 +109,76 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# run parameters\n",
+    "# run full_rvic\n",
     "output = osprey.full_rvic(\n",
     "    params_config = params_cfg,\n",
     "    convolve_config = convolve_cfg,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "full_rvicResponse(\n",
+       "    output='http://localhost:5002/outputs/d483316a-e89b-11ea-94ae-c86000e3f36f/sample.rvic.h0a.2013-01-01.nc'\n",
+       ")"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "output.get()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# dictionary inputs\n",
+    "output = osprey.full_rvic(\n",
+    "    params_config = {\n",
+    "        \"OPTIONS\":{\n",
+    "            \"CASEID\":\"sample\", \n",
+    "            \"GRIDID\":\"COLUMBIA\",\n",
+    "        },\n",
+    "        \"POUR_POINTS\":{\n",
+    "            \"FILE_NAME\":\"tests/data/samples/sample_pour.txt\"\n",
+    "        },\n",
+    "        \"UH_BOX\":{\n",
+    "            \"FILE_NAME\":\"tests/data/samples/uhbox.csv\"\n",
+    "        },\n",
+    "        \"ROUTING\": {\n",
+    "            \"FILE_NAME\":\"tests/data/samples/sample_flow_parameters.nc\"\n",
+    "        },\n",
+    "        \"DOMAIN\": {\n",
+    "            \"FILE_NAME\":\"tests/data/samples/sample_routing_domain.nc\"\n",
+    "        },\n",
+    "    },\n",
+    "    convolve_config = {\n",
+    "        \"OPTIONS\":{\n",
+    "            \"CASEID\":\"sample\", \n",
+    "            \"RUN_STARTDATE\": \"2012-12-01-00\", \n",
+    "            \"STOP_DATE\": \"2012-12-31\",\n",
+    "            \"CALENDAR\": \"standard\",\n",
+    "        },\n",
+    "        \"DOMAIN\":{\n",
+    "            \"FILE_NAME\":\"https://docker-dev03.pcic.uvic.ca/twitcher/ows/proxy/thredds/dodsC/datasets/RVIC/sample_routing_domain.nc\"\n",
+    "        },\n",
+    "        \"INPUT_FORCINGS\": {\n",
+    "            \"DATL_PATH\": \"https://docker-dev03.pcic.uvic.ca/twitcher/ows/proxy/thredds/dodsC/datasets/RVIC/\",\n",
+    "            \"DATL_FILE\": \"columbia_vicset2.nc\"\n",
+    "        }\n",
+    "    }\n",
     ")"
    ]
   },

--- a/notebooks/demo_individual/demo_full_rvic.ipynb
+++ b/notebooks/demo_individual/demo_full_rvic.ipynb
@@ -1,0 +1,141 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from birdy import WPSClient\n",
+    "from pkg_resources import resource_filename\n",
+    "\n",
+    "import requests"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os \n",
+    "while os.path.basename(os.getcwd()) != \"osprey\": # Ensure current directory is always 'osprey'\n",
+    "    os.chdir('../')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Set up wps application\n",
+    "url = 'http://localhost:5002/wps'\n",
+    "osprey = WPSClient(url=url)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "\u001b[0;31mType:\u001b[0m            WPSClient\n",
+       "\u001b[0;31mString form:\u001b[0m     <birdy.client.base.WPSClient object at 0x7f2cc12a2780>\n",
+       "\u001b[0;31mFile:\u001b[0m            ~/Desktop/osprey/venv/lib/python3.6/site-packages/birdy/client/base.py\n",
+       "\u001b[0;31mDocstring:\u001b[0m      \n",
+       "A Web Processing Service for Climate Data Analysis.\n",
+       "\n",
+       "Processes\n",
+       "---------\n",
+       "\n",
+       "convolution\n",
+       "    Aggregates the flow contribution from all upstream grid cellsat every timestep lagged according the Impuls Response Functions.\n",
+       "\n",
+       "parameters\n",
+       "    Develop impulse response functions using inputs from a configuration file or dictionary\n",
+       "\u001b[0;31mClass docstring:\u001b[0m\n",
+       "Returns a class where every public method is a WPS process available at\n",
+       "the given url.\n",
+       "\n",
+       "Example:\n",
+       "    >>> emu = WPSClient(url='<server url>')\n",
+       "    >>> emu.hello('stranger')\n",
+       "    'Hello stranger'\n",
+       "\u001b[0;31mInit docstring:\u001b[0m \n",
+       "Args:\n",
+       "    url (str): Link to WPS provider. config (Config): an instance\n",
+       "    processes: Specify a subset of processes to bind. Defaults to all\n",
+       "        processes.\n",
+       "    converters (dict): Correspondence of {mimetype: class} to convert\n",
+       "        this mimetype to a python object.\n",
+       "    username (str): passed to :class:`owslib.wps.WebProcessingService`\n",
+       "    password (str): passed to :class:`owslib.wps.WebProcessingService`\n",
+       "    headers (str): passed to :class:`owslib.wps.WebProcessingService`\n",
+       "    auth (requests.auth.AuthBase): requests-style auth class to authenticate,\n",
+       "        see https://2.python-requests.org/en/master/user/authentication/\n",
+       "    verify (bool): passed to :class:`owslib.wps.WebProcessingService`\n",
+       "    cert (str): passed to :class:`owslib.wps.WebProcessingService`\n",
+       "    verbose (str): passed to :class:`owslib.wps.WebProcessingService`\n",
+       "    progress (bool): If True, enable interactive user mode.\n",
+       "    version (str): WPS version to use.\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "osprey?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Object `osprey.full_rvic` not found.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Check info on `parameters` process\n",
+    "osprey.full_rvic?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/notebooks/demo_individual/demo_parameters.ipynb
+++ b/notebooks/demo_individual/demo_parameters.ipynb
@@ -160,7 +160,7 @@
    "source": [
     "# run parameters\n",
     "output = osprey.parameters(\n",
-    "    config = cfg_file_local\n",
+    "    params_config = cfg_file_local\n",
     ")"
    ]
   },
@@ -219,7 +219,7 @@
     "    temp_config.writelines(read_config.read())\n",
     "    temp_config.read()\n",
     "    output = osprey.parameters(\n",
-    "        config = temp_config.name\n",
+    "        params_config = temp_config.name\n",
     "    )"
    ]
   },
@@ -252,7 +252,7 @@
    "outputs": [],
    "source": [
     "output = osprey.parameters(\n",
-    "    config = {\n",
+    "    params_config = {\n",
     "        \"OPTIONS\": {\"CASEID\": \"sample\", \"GRIDID\": \"COLUMBIA\",},\n",
     "        \"POUR_POINTS\": {\n",
     "            \"FILE_NAME\": resource_filename(__name__, \"tests/data/samples/sample_pour.txt\")\n",

--- a/notebooks/demo_individual/demo_parameters.ipynb
+++ b/notebooks/demo_individual/demo_parameters.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -14,7 +14,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -25,7 +25,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -36,76 +36,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "\u001b[0;31mType:\u001b[0m            WPSClient\n",
-       "\u001b[0;31mString form:\u001b[0m     <birdy.client.base.WPSClient object at 0x7f6f493ea2e8>\n",
-       "\u001b[0;31mFile:\u001b[0m            ~/Desktop/osprey/venv/lib/python3.6/site-packages/birdy/client/base.py\n",
-       "\u001b[0;31mDocstring:\u001b[0m      \n",
-       "A Web Processing Service for Climate Data Analysis.\n",
-       "\n",
-       "Processes\n",
-       "---------\n",
-       "\n",
-       "convolution\n",
-       "    Aggregates the flow contribution from all upstream grid cellsat every timestep lagged according the Impuls Response Functions.\n",
-       "\n",
-       "parameters\n",
-       "    Develop impulse response functions using inputs from a configuration file or dictionary\n",
-       "\u001b[0;31mClass docstring:\u001b[0m\n",
-       "Returns a class where every public method is a WPS process available at\n",
-       "the given url.\n",
-       "\n",
-       "Example:\n",
-       "    >>> emu = WPSClient(url='<server url>')\n",
-       "    >>> emu.hello('stranger')\n",
-       "    'Hello stranger'\n",
-       "\u001b[0;31mInit docstring:\u001b[0m \n",
-       "Args:\n",
-       "    url (str): Link to WPS provider. config (Config): an instance\n",
-       "    processes: Specify a subset of processes to bind. Defaults to all\n",
-       "        processes.\n",
-       "    converters (dict): Correspondence of {mimetype: class} to convert\n",
-       "        this mimetype to a python object.\n",
-       "    username (str): passed to :class:`owslib.wps.WebProcessingService`\n",
-       "    password (str): passed to :class:`owslib.wps.WebProcessingService`\n",
-       "    headers (str): passed to :class:`owslib.wps.WebProcessingService`\n",
-       "    auth (requests.auth.AuthBase): requests-style auth class to authenticate,\n",
-       "        see https://2.python-requests.org/en/master/user/authentication/\n",
-       "    verify (bool): passed to :class:`owslib.wps.WebProcessingService`\n",
-       "    cert (str): passed to :class:`owslib.wps.WebProcessingService`\n",
-       "    verbose (str): passed to :class:`owslib.wps.WebProcessingService`\n",
-       "    progress (bool): If True, enable interactive user mode.\n",
-       "    version (str): WPS version to use.\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "osprey?"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "\u001b[0;31mSignature:\u001b[0m \u001b[0mosprey\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mparameters\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mconfig\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mnp\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;36m1\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mversion\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mTrue\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mloglevel\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m'INFO'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+       "\u001b[0;31mSignature:\u001b[0m \u001b[0mosprey\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mparameters\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mparams_config\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mnp\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;36m1\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mversion\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mTrue\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mloglevel\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m'INFO'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
        "\u001b[0;31mDocstring:\u001b[0m\n",
        "Develop impulse response functions using inputs from a configuration file or dictionary\n",
        "\n",
        "Parameters\n",
        "----------\n",
-       "config : string\n",
+       "params_config : string\n",
        "    Path to input configuration file or input dictionary\n",
        "np : integer\n",
        "    Number of processors used to run job\n",
@@ -133,7 +76,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -151,30 +94,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "# run parameters\n",
     "output = osprey.parameters(\n",
-    "    config = cfg_file\n",
+    "    params_config = cfg_file\n",
     ")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
        "parametersResponse(\n",
-       "    output='http://localhost:5002/outputs/b7be4b48-e713-11ea-a3bb-c86000e3f36f/sample.rvic.prm.COLUMBIA.20200825.nc'\n",
+       "    output='http://localhost:5002/outputs/431081ae-e8ac-11ea-94ae-c86000e3f36f/sample.rvic.prm.COLUMBIA.20200827.nc'\n",
        ")"
       ]
      },
-     "execution_count": 8,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -185,21 +128,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      " owslib.wps.WPSException : {'code': 'NoApplicableCode', 'locator': 'None', 'text': 'Process failed, please check server error log'}\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "# generate convolution\n",
+    "# dictionary input\n",
     "output = osprey.parameters(\n",
-    "    config = {\n",
+    "    params_config = {\n",
     "        \"OPTIONS\":{\n",
     "            \"CASEID\":\"sample\", \n",
     "            \"GRIDID\":\"COLUMBIA\",\n",
@@ -214,7 +149,7 @@
     "            \"FILE_NAME\":\"tests/data/samples/sample_flow_parameters.nc\"\n",
     "        },\n",
     "        \"DOMAIN\": {\n",
-    "            \"FILE_NAME\":\"https://docker-dev03.pcic.uvic.ca/twitcher/ows/proxy/thredds/dodsC/datasets/RVIC/sample_routing_domain.nc\"\n",
+    "            \"FILE_NAME\":\"tests/data/samples/sample_routing_domain.nc\"\n",
     "        },\n",
     "    }\n",
     ")"

--- a/osprey/processes/__init__.py
+++ b/osprey/processes/__init__.py
@@ -1,7 +1,9 @@
 from .wps_convolution import Convolution
 from .wps_parameters import Parameters
+from .wps_full_rvic import FullRVIC
 
 processes = [
     Convolution(),
     Parameters(),
+    FullRVIC(),
 ]

--- a/osprey/processes/wps_convolution.py
+++ b/osprey/processes/wps_convolution.py
@@ -13,8 +13,6 @@ from osprey.utils import (
     get_outfile,
 )
 
-from datetime import datetime, timedelta
-
 import os
 
 

--- a/osprey/processes/wps_convolution.py
+++ b/osprey/processes/wps_convolution.py
@@ -11,7 +11,6 @@ from wps_tools.io import nc_output, log_level
 from osprey.utils import (
     logger,
     config_hander,
-    config_file_builder,
     get_outfile,
 )
 

--- a/osprey/processes/wps_convolution.py
+++ b/osprey/processes/wps_convolution.py
@@ -102,14 +102,6 @@ class Convolution(Process):
         )
 
     def _handler(self, request, response):
-        if self.workdir == None:
-            self.workdir = "/tmp"
-            full_rvic = True
-        else:
-            full_rvic = False
-
-        if self.workdir == None:
-            self.workdir = "/tmp"
         loglevel = request.inputs["loglevel"][0].data
         log_handler(
             self,
@@ -147,8 +139,7 @@ class Convolution(Process):
             log_level=loglevel,
             process_step="build_output",
         )
-        if full_rvic:
-            return get_outfile(config, "hist")
+
         response.outputs["output"].file = get_outfile(config, "hist")
 
         log_handler(

--- a/osprey/processes/wps_convolution.py
+++ b/osprey/processes/wps_convolution.py
@@ -12,7 +12,6 @@ from osprey.utils import (
     logger,
     config_hander,
     config_file_builder,
-    run_rvic,
     get_outfile,
 )
 
@@ -68,7 +67,7 @@ class Convolution(Process):
                 "DATL_FILE": None,
                 "TIME_VAR": "time",
                 "LATITUDE_VAR": "lat",
-                "DATL_LIQ_FLDS": "RUNOFF, BASEFLOW",
+                "DATL_LIQ_FLDS": ["RUNOFF", "BASEFLOW"],
                 "START": None,
                 "END": None,
             },
@@ -141,9 +140,7 @@ class Convolution(Process):
                 self.workdir, convolution.__name__, unprocessed, self.config_template
             )
 
-        run_rvic(
-            self.workdir, convolution, version, config,
-        )
+        convolution(config)
 
         log_handler(
             self,

--- a/osprey/processes/wps_convolution.py
+++ b/osprey/processes/wps_convolution.py
@@ -107,6 +107,12 @@ class Convolution(Process):
     def _handler(self, request, response):
         if self.workdir == None:
             self.workdir = "/tmp"
+            full_rvic = True
+        else:
+            full_rvic = False
+
+        if self.workdir == None:
+            self.workdir = "/tmp"
         loglevel = request.inputs["loglevel"][0].data
         log_handler(
             self,
@@ -147,6 +153,8 @@ class Convolution(Process):
             log_level=loglevel,
             process_step="build_output",
         )
+        if full_rvic:
+            return get_outfile(config, "hist")
         response.outputs["output"].file = get_outfile(config, "hist")
 
         log_handler(

--- a/osprey/processes/wps_convolution.py
+++ b/osprey/processes/wps_convolution.py
@@ -81,7 +81,7 @@ class Convolution(Process):
         }
         inputs = [
             LiteralInput(
-                "config",
+                "convolve_config",
                 "Configuration",
                 abstract="Path to input configuration file or input dictionary",
                 data_type="string",
@@ -105,6 +105,8 @@ class Convolution(Process):
         )
 
     def _handler(self, request, response):
+        if self.workdir == None:
+            self.workdir = "/tmp"
         loglevel = request.inputs["loglevel"][0].data
         log_handler(
             self,
@@ -114,7 +116,7 @@ class Convolution(Process):
             log_level=loglevel,
             process_step="start",
         )
-        unprocessed = request.inputs["config"][0].data
+        unprocessed = request.inputs["convolve_config"][0].data
 
         log_handler(
             self,

--- a/osprey/processes/wps_full_rvic.py
+++ b/osprey/processes/wps_full_rvic.py
@@ -80,12 +80,6 @@ class FullRVIC(Process):
         )
 
     def _handler(self, request, response):
-        if request.inputs["version"][0].data:
-            logger.info(version)
-
-        params_config = request.inputs["params_config"][0].data
-        convolve_config = request.inputs["convolve_config"][0].data
-        np = request.inputs["np"][0].data
         loglevel = request.inputs["loglevel"][0].data
 
         log_handler(
@@ -106,17 +100,7 @@ class FullRVIC(Process):
             process_step="process",
         )
 
-        params_config_template = Parameters().config_template
-        if os.path.isfile(params_config):
-            config = read_config(params_config)
-        else:
-            params_config = params_config.replace("'", '"')
-            config = config_hander(
-                self.workdir, parameters.__name__, params_config, params_config_template
-            )
-
-        parameters(params_config, np)
-        params_output = get_outfile(config, "params")
+        params_output = Parameters()._handler(request, response).outputs["output"].file
 
         log_handler(
             self,

--- a/osprey/processes/wps_full_rvic.py
+++ b/osprey/processes/wps_full_rvic.py
@@ -2,6 +2,8 @@
 from pywps import (
     Process,
     LiteralInput,
+    ComplexOutput,
+    FORMATS,
 )
 
 # Tool imports
@@ -63,6 +65,13 @@ class FullRVIC(Process):
         ]
         outputs = [
             nc_output,
+            ComplexOutput(
+                "rvic_output",
+                "RVIC Output",
+                as_reference=True,
+                abstract="Output Netcdf File",
+                supported_formats=[FORMATS.NETCDF],
+            ),
         ]
 
         super(FullRVIC, self).__init__(
@@ -104,6 +113,6 @@ class FullRVIC(Process):
         convolve_output = (
             Convolution()._handler(request, response).outputs["output"].file
         )
-        response.outputs["output"].file = convolve_output
+        response.outputs["rvic_output"].file = convolve_output
 
         return response

--- a/osprey/processes/wps_full_rvic.py
+++ b/osprey/processes/wps_full_rvic.py
@@ -7,8 +7,7 @@ from pywps import (
 # Tool imports
 from rvic import version
 from pywps.app.Common import Metadata
-from osprey.processes.wps_convolution import Convolution
-from osprey.processes.wps_parameters import Parameters
+from osprey import parameters, convolution
 from osprey.utils import logger
 from wps_tools.utils import (
     collect_output_files,
@@ -72,8 +71,6 @@ class FullRVIC(Process):
         if request.inputs["version"][0].data:
             logger.info(version.short_version)
 
-        loglevel = request.inputs["loglevel"][0].data
-
         log_handler(
             self,
             response,
@@ -83,6 +80,11 @@ class FullRVIC(Process):
             process_step="start",
         )
 
+        params_config = request.inputs["params_config"][0].data
+        convolve_config = request.inputs["convolve_config"][0].data
+        np = request.inputs["np"][0].data
+        loglevel = request.inputs["loglevel"][0].data
+
         log_handler(
             self,
             response,
@@ -91,6 +93,8 @@ class FullRVIC(Process):
             log_level=loglevel,
             process_step="process",
         )
+        
+        parameters(params_config, np)
 
         log_handler(
             self,

--- a/osprey/processes/wps_full_rvic.py
+++ b/osprey/processes/wps_full_rvic.py
@@ -1,0 +1,113 @@
+# Processor imports
+from pywps import (
+    Process,
+    LiteralInput,
+)
+
+# Tool imports
+from rvic import version
+from pywps.app.Common import Metadata
+from osprey.processes.wps_convolution import Convolution
+from osprey.processes.wps_parameters import Parameters
+from osprey.utils import logger
+from wps_tools.utils import (
+    collect_output_files,
+    log_handler,
+)
+from wps_tools.io import (
+    log_level,
+    nc_output,
+)
+
+class FullRVIC(Process):
+    def __init__(self):
+        self.status_percentage_steps = {
+            "start": 0,
+            "process": 10,
+            "build_output": 95,
+            "complete": 100,
+        }
+        inputs = [
+            LiteralInput(
+                "params_config",
+                "Parameters Configuration",
+                abstract="Path to parameters module's input configuration file or input dictionary",
+                data_type="string",
+            ),
+            LiteralInput(
+                "convolve_config",
+                "Convolution Configuration",
+                abstract="Path to convolution module's input configuration file or input dictionary",
+                data_type="string",
+            ),
+            LiteralInput(
+                "np",
+                "numofproc",
+                default=1,
+                abstract="Number of processors used to run job",
+                data_type="integer",
+            ),
+            log_level,
+        ]
+        outputs = [
+            nc_output,
+        ]
+
+        super(FullRVIC, self).__init__(
+            self._handler,
+            identifier="full_rvic",
+            title="Full RVIC",
+            abstract="Run full RVIC process combining Parameters and Convolution modules",
+            metadata=[
+                Metadata("NetCDF processing"),
+                Metadata("Climate Data Operations"),
+            ],
+            inputs=inputs,
+            outputs=outputs,
+            store_supported=True,
+            status_supported=True,
+        )
+
+    def _handler(self, request, response):
+        if request.inputs["version"][0].data:
+            logger.info(version.short_version)
+
+        loglevel = request.inputs["loglevel"][0].data
+
+        log_handler(
+            self,
+            response,
+            "Starting Process",
+            logger,
+            log_level=loglevel,
+            process_step="start",
+        )
+
+        log_handler(
+            self,
+            response,
+            "Creating parameters",
+            logger,
+            log_level=loglevel,
+            process_step="process",
+        )
+
+        log_handler(
+            self,
+            response,
+            "Building final output",
+            logger,
+            log_level=loglevel,
+            process_step="build_output",
+        )
+
+        log_handler(
+            self,
+            response,
+            "Process Complete",
+            logger,
+            log_level=loglevel,
+            process_step="complete",
+        )
+        
+        return response

--- a/osprey/processes/wps_full_rvic.py
+++ b/osprey/processes/wps_full_rvic.py
@@ -7,7 +7,6 @@ from pywps import (
 )
 
 # Tool imports
-from rvic import version
 from rvic.convolution import convolution
 from rvic.parameters import parameters
 from rvic.core.config import read_config

--- a/osprey/processes/wps_full_rvic.py
+++ b/osprey/processes/wps_full_rvic.py
@@ -12,7 +12,7 @@ from rvic.convolution import convolution
 from rvic.parameters import parameters
 from rvic.core.config import read_config
 from pywps.app.Common import Metadata
-from osprey.utils import logger, config_hander, get_outfile, config_file_builder
+from osprey.utils import logger, config_hander, get_outfile
 from osprey.processes.wps_parameters import Parameters
 from osprey.processes.wps_convolution import Convolution
 from wps_tools.utils import (

--- a/osprey/processes/wps_full_rvic.py
+++ b/osprey/processes/wps_full_rvic.py
@@ -10,7 +10,8 @@ from rvic.convolution import convolution
 from rvic.parameters import parameters
 from rvic.core.config import read_config
 from pywps.app.Common import Metadata
-from osprey.utils import logger
+from osprey.utils import logger, config_hander, get_outfile
+from osprey.processes.wps_parameters import Parameters
 from wps_tools.utils import (
     collect_output_files,
     log_handler,
@@ -19,6 +20,7 @@ from wps_tools.io import (
     log_level,
     nc_output,
 )
+import os
 
 
 class FullRVIC(Process):
@@ -104,7 +106,17 @@ class FullRVIC(Process):
             process_step="process",
         )
 
+        params_config_template = Parameters().config_template
+        if os.path.isfile(params_config):
+            config = read_config(params_config)
+        else:
+            params_config = params_config.replace("'", '"')
+            config = config_hander(
+                self.workdir, parameters.__name__, params_config, params_config_template
+            )
+
         parameters(params_config, np)
+        params_output = get_outfile(config, "params")
 
         log_handler(
             self,

--- a/osprey/processes/wps_full_rvic.py
+++ b/osprey/processes/wps_full_rvic.py
@@ -6,8 +6,10 @@ from pywps import (
 
 # Tool imports
 from rvic import version
+from rvic.convolution import convolution
+from rvic.parameters import parameters
+from rvic.core.config import read_config
 from pywps.app.Common import Metadata
-from osprey import parameters, convolution
 from osprey.utils import logger
 from wps_tools.utils import (
     collect_output_files,
@@ -17,6 +19,7 @@ from wps_tools.io import (
     log_level,
     nc_output,
 )
+
 
 class FullRVIC(Process):
     def __init__(self):
@@ -38,6 +41,13 @@ class FullRVIC(Process):
                 "Convolution Configuration",
                 abstract="Path to convolution module's input configuration file or input dictionary",
                 data_type="string",
+            ),
+            LiteralInput(
+                "version",
+                "Version",
+                default=True,
+                abstract="Return RVIC version string",
+                data_type="boolean",
             ),
             LiteralInput(
                 "np",
@@ -69,7 +79,12 @@ class FullRVIC(Process):
 
     def _handler(self, request, response):
         if request.inputs["version"][0].data:
-            logger.info(version.short_version)
+            logger.info(version)
+
+        params_config = request.inputs["params_config"][0].data
+        convolve_config = request.inputs["convolve_config"][0].data
+        np = request.inputs["np"][0].data
+        loglevel = request.inputs["loglevel"][0].data
 
         log_handler(
             self,
@@ -80,11 +95,6 @@ class FullRVIC(Process):
             process_step="start",
         )
 
-        params_config = request.inputs["params_config"][0].data
-        convolve_config = request.inputs["convolve_config"][0].data
-        np = request.inputs["np"][0].data
-        loglevel = request.inputs["loglevel"][0].data
-
         log_handler(
             self,
             response,
@@ -93,7 +103,7 @@ class FullRVIC(Process):
             log_level=loglevel,
             process_step="process",
         )
-        
+
         parameters(params_config, np)
 
         log_handler(
@@ -113,5 +123,5 @@ class FullRVIC(Process):
             log_level=loglevel,
             process_step="complete",
         )
-        
+
         return response

--- a/osprey/processes/wps_full_rvic.py
+++ b/osprey/processes/wps_full_rvic.py
@@ -65,13 +65,6 @@ class FullRVIC(Process):
         ]
         outputs = [
             nc_output,
-            ComplexOutput(
-                "rvic_output",
-                "RVIC Output",
-                as_reference=True,
-                abstract="Output Netcdf File",
-                supported_formats=[FORMATS.NETCDF],
-            ),
         ]
 
         super(FullRVIC, self).__init__(
@@ -91,7 +84,7 @@ class FullRVIC(Process):
 
     def _handler(self, request, response):
 
-        params_output = Parameters()._handler(request, response).outputs["output"].file
+        params_output = Parameters()._handler(request, response)
 
         unprocessed = request.inputs["convolve_config"][0].data
         if os.path.isfile(unprocessed):
@@ -110,9 +103,7 @@ class FullRVIC(Process):
         cfg_file = config_file_builder(self.workdir, config)
         request.inputs["convolve_config"][0].data = cfg_file
 
-        convolve_output = (
-            Convolution()._handler(request, response).outputs["output"].file
-        )
-        response.outputs["rvic_output"].file = convolve_output
+        convolve_output = Convolution()._handler(request, response)
+        response.outputs["output"].file = convolve_output
 
         return response

--- a/osprey/processes/wps_full_rvic.py
+++ b/osprey/processes/wps_full_rvic.py
@@ -24,7 +24,6 @@ from wps_tools.io import (
     nc_output,
 )
 import os
-from json import loads, dumps
 
 
 class FullRVIC(Process):

--- a/osprey/processes/wps_full_rvic.py
+++ b/osprey/processes/wps_full_rvic.py
@@ -89,10 +89,9 @@ class FullRVIC(Process):
 
         unprocessed = request.inputs["convolve_config"][0].data
         if os.path.isfile(unprocessed):
-            config = loads(dumps(read_config(unprocessed)))
+            config = loads(dumps(read_config(unprocessed)))         # Convert OrderedDict to dict
 
         else:
-            unprocessed = unprocessed.replace("'", '"')
             config = config_hander(
                 self.workdir,
                 convolution.__name__,

--- a/osprey/processes/wps_full_rvic.py
+++ b/osprey/processes/wps_full_rvic.py
@@ -24,6 +24,7 @@ from wps_tools.io import (
     nc_output,
 )
 import os
+from json import loads, dumps
 
 
 class FullRVIC(Process):
@@ -88,7 +89,7 @@ class FullRVIC(Process):
 
         unprocessed = request.inputs["convolve_config"][0].data
         if os.path.isfile(unprocessed):
-            config = read_config(unprocessed)
+            config = loads(dumps(read_config(unprocessed)))
 
         else:
             unprocessed = unprocessed.replace("'", '"')
@@ -100,8 +101,7 @@ class FullRVIC(Process):
             )
 
         config["PARAM_FILE"]["FILE_NAME"] = params_output
-        cfg_file = config_file_builder(self.workdir, config)
-        request.inputs["convolve_config"][0].data = cfg_file
+        request.inputs["convolve_config"][0].data = config
 
         convolve_output = Convolution()._handler(request, response)
         response.outputs["output"].file = convolve_output

--- a/osprey/processes/wps_full_rvic.py
+++ b/osprey/processes/wps_full_rvic.py
@@ -89,7 +89,9 @@ class FullRVIC(Process):
 
         unprocessed = request.inputs["convolve_config"][0].data
         if os.path.isfile(unprocessed):
-            config = loads(dumps(read_config(unprocessed)))         # Convert OrderedDict to dict
+            config = loads(
+                dumps(read_config(unprocessed))
+            )  # Convert OrderedDict to dict
 
         else:
             config = config_hander(

--- a/osprey/processes/wps_parameters.py
+++ b/osprey/processes/wps_parameters.py
@@ -136,6 +136,10 @@ class Parameters(Process):
     def _handler(self, request, response):
         if self.workdir == None:
             self.workdir = "/tmp"
+            full_rvic = True
+        else:
+            full_rvic = False
+
         if request.inputs["version"][0].data:
             logger.info(version)
 
@@ -178,6 +182,8 @@ class Parameters(Process):
             log_level=loglevel,
             process_step="build_output",
         )
+        if full_rvic:
+            return get_outfile(config, "params")
         response.outputs["output"].file = get_outfile(config, "params")
 
         log_handler(
@@ -188,4 +194,5 @@ class Parameters(Process):
             log_level=loglevel,
             process_step="complete",
         )
+
         return response

--- a/osprey/processes/wps_parameters.py
+++ b/osprey/processes/wps_parameters.py
@@ -86,8 +86,8 @@ class Parameters(Process):
         }
         inputs = [
             LiteralInput(
-                "config",
-                "Configuration",
+                "params_config",
+                "Parameters Configuration",
                 abstract="Path to input configuration file or input dictionary",
                 data_type="string",
             ),
@@ -128,12 +128,14 @@ class Parameters(Process):
         )
 
     def collect_args(self, request):
-        unprocessed = request.inputs["config"][0].data
+        unprocessed = request.inputs["params_config"][0].data
         np = request.inputs["np"][0].data
         loglevel = request.inputs["loglevel"][0].data
         return (unprocessed, np, loglevel)
 
     def _handler(self, request, response):
+        if self.workdir == None:
+            self.workdir = "/tmp"
         if request.inputs["version"][0].data:
             logger.info(version)
 

--- a/osprey/processes/wps_parameters.py
+++ b/osprey/processes/wps_parameters.py
@@ -16,7 +16,6 @@ from wps_tools.io import (
 )
 from osprey.utils import (
     logger,
-    run_rvic,
     config_hander,
     config_file_builder,
     get_outfile,
@@ -24,7 +23,6 @@ from osprey.utils import (
 
 # Library imports
 import os
-import json
 from datetime import datetime
 
 
@@ -170,9 +168,7 @@ class Parameters(Process):
                 self.workdir, parameters.__name__, unprocessed, self.config_template
             )
 
-        run_rvic(
-            self.workdir, parameters, version, config,
-        )
+        parameters(config, np)
 
         log_handler(
             self,

--- a/osprey/processes/wps_parameters.py
+++ b/osprey/processes/wps_parameters.py
@@ -133,12 +133,6 @@ class Parameters(Process):
         return (unprocessed, np, loglevel)
 
     def _handler(self, request, response):
-        if self.workdir == None:
-            self.workdir = "/tmp"
-            full_rvic = True
-        else:
-            full_rvic = False
-
         if request.inputs["version"][0].data:
             logger.info(version)
 
@@ -180,8 +174,7 @@ class Parameters(Process):
             log_level=loglevel,
             process_step="build_output",
         )
-        if full_rvic:
-            return get_outfile(config, "params")
+
         response.outputs["output"].file = get_outfile(config, "params")
 
         log_handler(

--- a/osprey/processes/wps_parameters.py
+++ b/osprey/processes/wps_parameters.py
@@ -17,7 +17,6 @@ from wps_tools.io import (
 from osprey.utils import (
     logger,
     config_hander,
-    config_file_builder,
     get_outfile,
 )
 

--- a/osprey/processes/wps_parameters.py
+++ b/osprey/processes/wps_parameters.py
@@ -23,8 +23,6 @@ from osprey.utils import (
 
 # Library imports
 import os
-from datetime import datetime
-from pkg_resources import resource_filename
 
 
 class Parameters(Process):

--- a/osprey/utils.py
+++ b/osprey/utils.py
@@ -72,33 +72,6 @@ def config_hander(workdir, modulue_name, unprocessed, config_template):
         raise ProcessError("Invalid config key provided")
 
 
-def config_file_builder(workdir, config):
-    """
-    This function is used for RVIC1.1.0.post1 only since the version requires Configuration input
-    to be a .cfg filepath. The function uses information from config to create the file.
-    """
-    cfg_filepath = os.path.join(workdir, "convolve_file.cfg")
-    with open(cfg_filepath, "w") as cfg_file:
-        for upper_key in config.keys():
-            cfg_file.write(f"[{upper_key}]\n")
-            for k, v in config[upper_key].items():
-                if isinstance(v, Iterable) and type(v) != str:
-                    v_string = ", ".join(v)
-                else:
-                    v_string = str(v)
-                cfg_file.write(f"{k}: {v_string}\n")
-
-    return cfg_filepath
-
-
-def run_rvic(workdir, rvic_module, version, config):
-    if version == "1.1.0-1":  # RVIC1.1.0.post1
-        cfg_filepath = config_file_builder(workdir, config)
-        rvic_module(cfg_filepath)
-    elif version == "1.1.1":  # RVIC1.1.1
-        rvic_module(config)
-
-
 def get_outfile(config, dir_name):
     case_id = config["OPTIONS"]["CASEID"]
     case_dir = config["OPTIONS"]["CASE_DIR"]

--- a/osprey/utils.py
+++ b/osprey/utils.py
@@ -42,7 +42,8 @@ def config_hander(workdir, modulue_name, unprocessed, config_template):
     If CASE_DIR and REST_DATE are not provided from a user, their values are derived from
     CASEID and STOP_DATE by default.
     """
-    unprocessed = json.loads(unprocessed)
+    if type(unprocessed) == str:
+        unprocessed = json.loads(unprocessed)
     try:
         for upper_key in unprocessed.keys():
             for lower_key in unprocessed[upper_key].keys():

--- a/osprey/utils.py
+++ b/osprey/utils.py
@@ -2,7 +2,6 @@ from pkg_resources import resource_filename
 from pywps.app.exceptions import ProcessError
 import logging
 import os
-import json
 import requests
 from datetime import datetime, timedelta
 from collections.abc import Iterable

--- a/osprey/utils.py
+++ b/osprey/utils.py
@@ -43,7 +43,7 @@ def config_hander(workdir, modulue_name, unprocessed, config_template):
     CASEID and STOP_DATE by default.
     """
     if type(unprocessed) == str:
-        unprocessed = json.loads(unprocessed)
+        unprocessed = eval(unprocessed)
     try:
         for upper_key in unprocessed.keys():
             for lower_key in unprocessed[upper_key].keys():

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,3 @@ psutil
 rvic==1.1.1
 nchelpers==5.5.7
 wps-tools==0.1.2
-pandas<0.20.0
-numpy<1.18.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ psutil
 rvic==1.1.1
 nchelpers==5.5.7
 wps-tools==0.1.2
+pandas<0.20.0
+numpy<1.18.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ pywps>=4.2
 jinja2
 click
 psutil
-rvic==1.1.0post1
+rvic==1.1.1
 nchelpers==5.5.7
 wps-tools==0.1.2

--- a/tests/test_wps_caps.py
+++ b/tests/test_wps_caps.py
@@ -11,5 +11,6 @@ def test_wps_caps():
     )
     assert sorted(names.split()) == [
         "convolution",
+        "full_rvic",
         "parameters",
     ]

--- a/tests/test_wps_convolution.py
+++ b/tests/test_wps_convolution.py
@@ -34,5 +34,5 @@ from osprey.processes.wps_convolution import Convolution
     ],
 )
 def test_wps_convolution(config):
-    params = ("config={0};").format(config)
+    params = ("convolve_config={0};").format(config)
     run_wps_process(Convolution(), params)

--- a/tests/test_wps_full_rvic.py
+++ b/tests/test_wps_full_rvic.py
@@ -16,6 +16,44 @@ from osprey.processes.wps_full_rvic import FullRVIC
             resource_filename(__name__, "data/samples/sample_parameter_config.cfg"),
             resource_filename(__name__, "configs/convolve_opendap.cfg"),
         ),
+        (
+            {
+                "OPTIONS": {"CASEID": "sample", "GRIDID": "COLUMBIA",},
+                "POUR_POINTS": {
+                    "FILE_NAME": resource_filename(
+                        __name__, "data/samples/sample_pour.txt"
+                    )
+                },
+                "UH_BOX": {
+                    "FILE_NAME": resource_filename(__name__, "data/samples/uhbox.csv")
+                },
+                "ROUTING": {
+                    "FILE_NAME": resource_filename(
+                        __name__, "data/samples/sample_flow_parameters.nc"
+                    )
+                },
+                "DOMAIN": {
+                    "FILE_NAME": resource_filename(
+                        __name__, "data/samples/sample_routing_domain.nc"
+                    )
+                },
+            },
+            {
+                "OPTIONS": {
+                    "CASEID": "sample",
+                    "RUN_STARTDATE": "2012-12-01-00",
+                    "STOP_DATE": "2012-12-31",
+                    "CALENDAR": "standard",
+                },
+                "DOMAIN": {
+                    "FILE_NAME": "https://docker-dev03.pcic.uvic.ca/twitcher/ows/proxy/thredds/dodsC/datasets/RVIC/sample_routing_domain.nc"
+                },
+                "INPUT_FORCINGS": {
+                    "DATL_PATH": "https://docker-dev03.pcic.uvic.ca/twitcher/ows/proxy/thredds/dodsC/datasets/RVIC/",
+                    "DATL_FILE": "columbia_vicset2.nc",
+                },
+            },
+        ),
     ],
 )
 def test_full_rvic(params_config, convolve_config):

--- a/tests/test_wps_full_rvic.py
+++ b/tests/test_wps_full_rvic.py
@@ -1,0 +1,23 @@
+from pytest import mark
+from pywps import Service
+from pywps.tests import client_for, assert_response_success
+from pkg_resources import resource_filename
+
+from wps_tools.testing import run_wps_process
+from osprey.processes.wps_full_rvic import FullRVIC
+
+
+@mark.slow
+@mark.online
+@mark.parametrize(
+    ("params_config", "convolve_config"),
+    [
+        (
+            resource_filename(__name__, "data/samples/sample_parameter_config.cfg"),
+            resource_filename(__name__, "configs/convolve_opendap.cfg"),
+        ),
+    ],
+)
+def test_full_rvic(params_config, convolve_config):
+    params = f"params_config={params_config};" f"convolve_config={convolve_config};"
+    run_wps_process(FullRVIC(), params)

--- a/tests/test_wps_parameters.py
+++ b/tests/test_wps_parameters.py
@@ -60,5 +60,5 @@ def test_parameters_https(config, conftest_make_mock_urls):
         read_config = open(config, "r")
         temp_config.writelines(read_config.read())
         temp_config.read()
-        params = f"config={temp_config.name};"
+        params = f"params_config={temp_config.name};"
         run_wps_process(Parameters(), params)

--- a/tests/test_wps_parameters.py
+++ b/tests/test_wps_parameters.py
@@ -35,7 +35,7 @@ from osprey.utils import replace_filenames
 )
 def test_parameters_local(config):
     if type(config) == dict:
-        params = ("config={0};").format(config)
+        params = ("params_config={0};").format(config)
         run_wps_process(Parameters(), params)
     else:
         config_name = os.path.splitext(config)[0]  # Remove .cfg extension
@@ -44,5 +44,5 @@ def test_parameters_local(config):
         ) as temp_config:
             replace_filenames(config, temp_config)
             temp_config.read()
-            params = f"config={temp_config.name};"
+            params = f"params_config={temp_config.name};"
             run_wps_process(Parameters(), params)


### PR DESCRIPTION
This PR resolves #29 

`wps_full_rvic` is implemented to mitigate the redundancy of running `wps_parameters` and `wps_convolution` processes separately. The process flow is determined referring to the [note](https://pcic.uvic.ca/confluence/pages/viewpage.action?spaceKey=CSG&title=Meeting+Notes+2018-05-09+-+RVIC+demo) by @corviday.

- The process takes two inputs: `params_config` and `convolve_config`
- Output of `wps_parameters` is automatically used to run `wps_convolution`
- Both  `str` (`.cfg` filepath) and `dict` data types are allowed for the inputs.