### PR TITLE
Replace rvic with rvic-daccs

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -23,13 +23,13 @@ jobs:
         pip install -U pip pytest
         pip install -r requirements.txt
         pip install -e .[dev]
-        #- name: Test with pytest (full)
-        #if: github.ref == 'refs/heads/master'
-        #run: |
-        #py.test -v
-        #- name: Test with pytest (fast)
-        #if: github.ref != 'refs/heads/master'
-        #run: |
-        #py.test -m "not slow" -v
+    - name: Test with pytest (full)
+      if: github.ref == 'refs/heads/master'
+      run: |
+        py.test -v
+    - name: Test with pytest (fast)
+      if: github.ref != 'refs/heads/master'
+      run: |
+        py.test -m "not slow" -v
     - name: Code Quality
       run: black . --check

--- a/README.rst
+++ b/README.rst
@@ -49,22 +49,15 @@ and activated as follows (second `venv` can be replaced with environment name of
    (venv) $ pip install -r requirements.txt
    (venv) $ pip install -e .[dev]
 
+Testing
+^^^^^^^
+
+The tests can be run by simply running ``pytest`` on the command line.
+
 Contributing
 ------------
 
 You can find information about contributing in our `Developer Guide`_.
-
-Testing
-^^^^^^^
-
-Upon installation, the tests for each process will fail due to issues in ``RVIC``. In order to fix them, two modules in the
-``rvic`` site-package in your ``venv`` need to be modified as follows:
-
-1. In line 188 of ``rvic/parameters.py``, change ``pour_points.ix`` to ``pour_points.loc`` (`parameters.py issue`_).
-
-2. From lines 277 to 298 of ``rvic/core/share.py``, change each instance of ``valid_range`` to ``range`` (`share.py issue`_).
-
-After these changes, the tests can be run by running `pytest` on the command line.
 
 Releasing
 ^^^^^^^^^

--- a/README.rst
+++ b/README.rst
@@ -49,10 +49,6 @@ and activated as follows (second `venv` can be replaced with environment name of
    (venv) $ pip install -r requirements.txt
    (venv) $ pip install -e .[dev]
 
-Testing
-^^^^^^^
-
-The tests can be run by simply running ``pytest`` on the command line.
 
 Contributing
 ------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ pywps>=4.2
 jinja2
 click
 psutil
-rvic-daccs==1.1.1
+rvic-daccs==1.1.2
 nchelpers==5.5.7
 wps-tools==0.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ pywps>=4.2
 jinja2
 click
 psutil
-rvic==1.1.1
+rvic-daccs==1.1.1
 nchelpers==5.5.7
 wps-tools==0.1.2


### PR DESCRIPTION
This PR resolves #34 

RVIC's internal issues are finally resolved by using rvic-daccs 1.1.2. CI can now run pytest without errors and the sourcecode modification process is not required anymore.