### PR TITLE
I39 ci pytest

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -26,10 +26,10 @@ jobs:
     - name: Test with pytest (full)
       if: github.ref == 'refs/heads/master'
       run: |
-        py.test -v
+        py.test -m "not online" -v
     - name: Test with pytest (fast)
       if: github.ref != 'refs/heads/master'
       run: |
-        py.test -m "not slow" -v
+        py.test -m "not online and not slow" -v
     - name: Code Quality
       run: black . --check

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+markers =
+    online: marks tests that use online resources (deselect with '-m "not online"')
+    slow: marks tests that are slow (deselect with '-m "not slow"')

--- a/tests/data/configs/convolve_mixed.cfg
+++ b/tests/data/configs/convolve_mixed.cfg
@@ -53,7 +53,7 @@ STOP_N : -999
 
 #--date in yyyy-mm-dd format, sets the run length with STOP_OPTION and STOP_N (integer)  --#
 #STOP_DATE : -999
-STOP_DATE : 1945-12-31
+STOP_DATE : 1945-01-31
 
 #-- ====================================== --#
 

--- a/tests/test_wps_full_rvic.py
+++ b/tests/test_wps_full_rvic.py
@@ -13,8 +13,8 @@ from osprey.processes.wps_full_rvic import FullRVIC
     ("params_config", "convolve_config"),
     [
         (
-            resource_filename(__name__, "data/samples/sample_parameter_config.cfg"),
-            resource_filename(__name__, "configs/convolve_opendap.cfg"),
+            resource_filename(__name__, "data/configs/parameters_local.cfg"),
+            resource_filename(__name__, "data/configs/convolve_opendap.cfg"),
         ),
         (
             {


### PR DESCRIPTION
Tests using opendap resources resulted in pytest failure. The tests are marked as `online` and deselected from CI actions.