### PR TITLE
Update jupyter lab demos and pytest files

### DIFF
--- a/notebooks/demo_individual/demo_convolution.ipynb
+++ b/notebooks/demo_individual/demo_convolution.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -14,7 +14,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -25,7 +25,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -36,7 +36,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -72,25 +72,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "/home/sangwonl/Desktop/osprey/tests/configs/convolve_opendap.cfg\n"
+      "/home/sangwonl/Desktop/osprey/tests/data/configs/convolve_opendap.cfg\n"
      ]
     }
    ],
    "source": [
-    "cfg_file = resource_filename(\"tests\", \"configs/convolve_opendap.cfg\")\n",
+    "cfg_file = resource_filename(\"tests\", \"data/configs/convolve_opendap.cfg\")\n",
     "print(cfg_file)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -102,18 +102,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
        "convolutionResponse(\n",
-       "    output='http://localhost:5002/outputs/b2fab4d0-e8ac-11ea-94ae-c86000e3f36f/sample.rvic.h0a.2013-01-01.nc'\n",
+       "    output='http://localhost:5002/outputs/8121933c-f79a-11ea-9a48-c86000e3f36f/sample.rvic.h0a.2013-01-01.nc'\n",
        ")"
       ]
      },
-     "execution_count": null,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -124,7 +124,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -153,18 +153,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
        "convolutionResponse(\n",
-       "    output='http://localhost:5002/outputs/b9b3e6d4-e8ac-11ea-94ae-c86000e3f36f/sample.rvic.h0a.2013-01-01.nc'\n",
+       "    output='http://localhost:5002/outputs/8a9b36fc-f79a-11ea-9a48-c86000e3f36f/sample.rvic.h0a.2013-01-01.nc'\n",
        ")"
       ]
      },
-     "execution_count": null,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/notebooks/demo_individual/demo_full_rvic.ipynb
+++ b/notebooks/demo_individual/demo_full_rvic.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -14,7 +14,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -25,7 +25,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -36,7 +36,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -70,7 +70,7 @@
        "-------\n",
        "output : ComplexData:mimetype:`application/x-netcdf`\n",
        "    Output Netcdf File\n",
-       "\u001b[0;31mFile:\u001b[0m      ~/Desktop/osprey/</home/sangwonl/Desktop/osprey/venv/lib/python3.6/site-packages/birdy/client/base.py-14>\n",
+       "\u001b[0;31mFile:\u001b[0m      ~/Desktop/osprey/</home/sangwonl/Desktop/osprey/venv/lib/python3.6/site-packages/birdy/client/base.py-2>\n",
        "\u001b[0;31mType:\u001b[0m      method\n"
       ]
      },
@@ -85,27 +85,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "/home/sangwonl/Desktop/osprey/tests/data/samples/sample_parameter_config.cfg\n"
+      "/home/sangwonl/Desktop/osprey/tests/data/configs/parameters_local.cfg\n"
      ]
     }
    ],
    "source": [
-    "params_cfg = resource_filename(\"tests\", \"data/samples/sample_parameter_config.cfg\")\n",
-    "convolve_cfg = resource_filename(\"tests\", \"configs/convolve_opendap.cfg\")\n",
+    "params_cfg = resource_filename(\"tests\", \"data/configs/parameters_local.cfg\")\n",
+    "convolve_cfg = resource_filename(\"tests\", \"data/configs/convolve_opendap.cfg\")\n",
     "\n",
     "print(params_cfg)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -118,18 +118,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
        "full_rvicResponse(\n",
-       "    output='http://localhost:5002/outputs/d483316a-e89b-11ea-94ae-c86000e3f36f/sample.rvic.h0a.2013-01-01.nc'\n",
+       "    output='http://localhost:5002/outputs/69f81022-f79b-11ea-9a48-c86000e3f36f/sample.rvic.h0a.2013-01-01.nc'\n",
        ")"
       ]
      },
-     "execution_count": null,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -140,7 +140,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -180,6 +180,28 @@
     "        }\n",
     "    }\n",
     ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "full_rvicResponse(\n",
+       "    output='http://localhost:5002/outputs/79e5d8b6-f79b-11ea-9a48-c86000e3f36f/sample.rvic.h0a.2013-01-01.nc'\n",
+       ")"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "output.get()"
    ]
   },
   {

--- a/notebooks/demo_individual/demo_parameters.ipynb
+++ b/notebooks/demo_individual/demo_parameters.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -17,7 +17,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -28,7 +28,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -39,64 +39,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "\u001b[0;31mType:\u001b[0m            WPSClient\n",
-       "\u001b[0;31mString form:\u001b[0m     <birdy.client.base.WPSClient object at 0x7fc1e50f80f0>\n",
-       "\u001b[0;31mFile:\u001b[0m            ~/Desktop/osprey/venv/lib/python3.6/site-packages/birdy/client/base.py\n",
-       "\u001b[0;31mDocstring:\u001b[0m      \n",
-       "A Web Processing Service for Climate Data Analysis.\n",
-       "\n",
-       "Processes\n",
-       "---------\n",
-       "\n",
-       "convolution\n",
-       "    Aggregates the flow contribution from all upstream grid cellsat every timestep lagged according the Impuls Response Functions.\n",
-       "\n",
-       "parameters\n",
-       "    Develop impulse response functions using inputs from a configuration file or dictionary\n",
-       "\u001b[0;31mClass docstring:\u001b[0m\n",
-       "Returns a class where every public method is a WPS process available at\n",
-       "the given url.\n",
-       "\n",
-       "Example:\n",
-       "    >>> emu = WPSClient(url='<server url>')\n",
-       "    >>> emu.hello('stranger')\n",
-       "    'Hello stranger'\n",
-       "\u001b[0;31mInit docstring:\u001b[0m \n",
-       "Args:\n",
-       "    url (str): Link to WPS provider. config (Config): an instance\n",
-       "    processes: Specify a subset of processes to bind. Defaults to all\n",
-       "        processes.\n",
-       "    converters (dict): Correspondence of {mimetype: class} to convert\n",
-       "        this mimetype to a python object.\n",
-       "    username (str): passed to :class:`owslib.wps.WebProcessingService`\n",
-       "    password (str): passed to :class:`owslib.wps.WebProcessingService`\n",
-       "    headers (str): passed to :class:`owslib.wps.WebProcessingService`\n",
-       "    auth (requests.auth.AuthBase): requests-style auth class to authenticate,\n",
-       "        see https://2.python-requests.org/en/master/user/authentication/\n",
-       "    verify (bool): passed to :class:`owslib.wps.WebProcessingService`\n",
-       "    cert (str): passed to :class:`owslib.wps.WebProcessingService`\n",
-       "    verbose (str): passed to :class:`owslib.wps.WebProcessingService`\n",
-       "    progress (bool): If True, enable interactive user mode.\n",
-       "    version (str): WPS version to use.\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "osprey?"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -136,25 +79,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "/home/sangwonl/Desktop/osprey/tests/data/samples/sample_parameter_config.cfg\n"
+      "/home/sangwonl/Desktop/osprey/tests/data/configs/parameters_local.cfg\n"
      ]
     }
    ],
    "source": [
-    "cfg_file_local = resource_filename(\"tests\", \"data/samples/sample_parameter_config.cfg\")\n",
+    "cfg_file_local = resource_filename(\"tests\", \"data/configs/parameters_local.cfg\")\n",
     "print(cfg_file_local)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -166,18 +109,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
        "parametersResponse(\n",
-       "    output='http://localhost:5002/outputs/c24ad282-f2d7-11ea-9093-c86000e3f36f/sample.rvic.prm.COLUMBIA.20200909.nc'\n",
+       "    output='http://localhost:5002/outputs/4267a27a-f79b-11ea-9a48-c86000e3f36f/sample.rvic.prm.COLUMBIA.20200915.nc'\n",
        ")"
       ]
      },
-     "execution_count": null,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -188,26 +131,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "/home/sangwonl/Desktop/osprey/tests/configs/parameter_mixed.cfg\n"
+      "/home/sangwonl/Desktop/osprey/tests/data/configs/parameters_mixed.cfg\n"
      ]
     }
    ],
    "source": [
     "# FILE_PATHS are a mix of local paths and https urls\n",
-    "cfg_file_mixed = resource_filename(\"tests\", \"configs/parameter_mixed.cfg\")\n",
+    "cfg_file_mixed = resource_filename(\"tests\", \"data/configs/parameters_mixed.cfg\")\n",
     "print(cfg_file_mixed)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -225,18 +168,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
        "parametersResponse(\n",
-       "    output='http://localhost:5002/outputs/cf30040e-f2d7-11ea-9093-c86000e3f36f/sample.rvic.prm.COLUMBIA.20200909.nc'\n",
+       "    output='http://localhost:5002/outputs/447c2626-f79b-11ea-9a48-c86000e3f36f/sample.rvic.prm.COLUMBIA.20200915.nc'\n",
        ")"
       ]
      },
-     "execution_count": null,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -247,7 +190,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -276,18 +219,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
        "parametersResponse(\n",
-       "    output='http://localhost:5002/outputs/6828fa26-f2d8-11ea-9093-c86000e3f36f/sample.rvic.prm.COLUMBIA.20200909.nc'\n",
+       "    output='http://localhost:5002/outputs/476183ea-f79b-11ea-9a48-c86000e3f36f/sample.rvic.prm.COLUMBIA.20200915.nc'\n",
        ")"
       ]
      },
-     "execution_count": null,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/osprey/utils.py
+++ b/osprey/utils.py
@@ -19,23 +19,6 @@ handler.setFormatter(formatter)
 logger.addHandler(handler)
 
 
-def replace_filenames(config, temp_config):
-    """
-    Replace relative filepaths in config file with
-    absolute paths.
-    Parameters:
-        config (str): Original config file
-        temp_config (TemporaryFile): New config file (to be passed into process)
-    """
-    with open(config, "r") as old_config:
-        filedata = old_config.read()
-
-    rel_dir = "tests/data"
-    abs_dir = os.path.abspath(resource_filename("tests", "data"))
-    newdata = filedata.replace(rel_dir, abs_dir)
-    temp_config.writelines(newdata)
-
-
 def replace_urls(config_file, outdir):
     """
     Copy https URLs to local storage and replace URLs

--- a/tests/test_wps_convolution.py
+++ b/tests/test_wps_convolution.py
@@ -1,6 +1,4 @@
 from pytest import mark
-from pywps import Service
-from pywps.tests import client_for, assert_response_success
 from pkg_resources import resource_filename
 
 from wps_tools.testing import run_wps_process

--- a/tests/test_wps_full_rvic.py
+++ b/tests/test_wps_full_rvic.py
@@ -1,6 +1,4 @@
 from pytest import mark
-from pywps import Service
-from pywps.tests import client_for, assert_response_success
 from pkg_resources import resource_filename
 
 from wps_tools.testing import run_wps_process

--- a/tests/test_wps_parameters.py
+++ b/tests/test_wps_parameters.py
@@ -5,7 +5,6 @@ from tempfile import NamedTemporaryFile
 
 from wps_tools.testing import run_wps_process
 from osprey.processes.wps_parameters import Parameters
-from osprey.utils import replace_filenames
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR resolves #42 

Filepaths to sample configuration files have been modified in jupyter lab demos. Redundant python package imports have been removed from test files as well.

Edit: I couldn't find a reason to keep `replace_filenames` function in `utils.py`, thus removed.