### PR TITLE
replace_urls copies original configuration files to tmp

### DIFF
--- a/notebooks/demo_individual/demo_parameters.ipynb
+++ b/notebooks/demo_individual/demo_parameters.ipynb
@@ -2,22 +2,19 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
     "from birdy import WPSClient\n",
     "from pkg_resources import resource_filename\n",
     "\n",
-    "import requests\n",
-    "\n",
-    "# For mixed demo\n",
-    "from tempfile import NamedTemporaryFile"
+    "import requests"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -28,7 +25,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -39,64 +36,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "\u001b[0;31mType:\u001b[0m            WPSClient\n",
-       "\u001b[0;31mString form:\u001b[0m     <birdy.client.base.WPSClient object at 0x7fc1e50f80f0>\n",
-       "\u001b[0;31mFile:\u001b[0m            ~/Desktop/osprey/venv/lib/python3.6/site-packages/birdy/client/base.py\n",
-       "\u001b[0;31mDocstring:\u001b[0m      \n",
-       "A Web Processing Service for Climate Data Analysis.\n",
-       "\n",
-       "Processes\n",
-       "---------\n",
-       "\n",
-       "convolution\n",
-       "    Aggregates the flow contribution from all upstream grid cellsat every timestep lagged according the Impuls Response Functions.\n",
-       "\n",
-       "parameters\n",
-       "    Develop impulse response functions using inputs from a configuration file or dictionary\n",
-       "\u001b[0;31mClass docstring:\u001b[0m\n",
-       "Returns a class where every public method is a WPS process available at\n",
-       "the given url.\n",
-       "\n",
-       "Example:\n",
-       "    >>> emu = WPSClient(url='<server url>')\n",
-       "    >>> emu.hello('stranger')\n",
-       "    'Hello stranger'\n",
-       "\u001b[0;31mInit docstring:\u001b[0m \n",
-       "Args:\n",
-       "    url (str): Link to WPS provider. config (Config): an instance\n",
-       "    processes: Specify a subset of processes to bind. Defaults to all\n",
-       "        processes.\n",
-       "    converters (dict): Correspondence of {mimetype: class} to convert\n",
-       "        this mimetype to a python object.\n",
-       "    username (str): passed to :class:`owslib.wps.WebProcessingService`\n",
-       "    password (str): passed to :class:`owslib.wps.WebProcessingService`\n",
-       "    headers (str): passed to :class:`owslib.wps.WebProcessingService`\n",
-       "    auth (requests.auth.AuthBase): requests-style auth class to authenticate,\n",
-       "        see https://2.python-requests.org/en/master/user/authentication/\n",
-       "    verify (bool): passed to :class:`owslib.wps.WebProcessingService`\n",
-       "    cert (str): passed to :class:`owslib.wps.WebProcessingService`\n",
-       "    verbose (str): passed to :class:`owslib.wps.WebProcessingService`\n",
-       "    progress (bool): If True, enable interactive user mode.\n",
-       "    version (str): WPS version to use.\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "osprey?"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -136,25 +76,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "/home/sangwonl/Desktop/osprey/tests/data/samples/sample_parameter_config.cfg\n"
+      "/home/sangwonl/Desktop/osprey/tests/data/configs/parameters_local.cfg\n"
      ]
     }
    ],
    "source": [
-    "cfg_file_local = resource_filename(\"tests\", \"data/samples/sample_parameter_config.cfg\")\n",
+    "cfg_file_local = resource_filename(\"tests\", \"data/configs/parameters_local.cfg\")\n",
     "print(cfg_file_local)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -166,18 +106,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
        "parametersResponse(\n",
-       "    output='http://localhost:5002/outputs/c24ad282-f2d7-11ea-9093-c86000e3f36f/sample.rvic.prm.COLUMBIA.20200909.nc'\n",
+       "    output='http://localhost:5002/outputs/b3e29b5e-f7ae-11ea-9a48-c86000e3f36f/sample.rvic.prm.COLUMBIA.20200915.nc'\n",
        ")"
       ]
      },
-     "execution_count": null,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -188,55 +128,48 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "/home/sangwonl/Desktop/osprey/tests/configs/parameter_mixed.cfg\n"
+      "/home/sangwonl/Desktop/osprey/tests/data/configs/parameters_mixed.cfg\n"
      ]
     }
    ],
    "source": [
     "# FILE_PATHS are a mix of local paths and https urls\n",
-    "cfg_file_mixed = resource_filename(\"tests\", \"configs/parameter_mixed.cfg\")\n",
+    "cfg_file_mixed = resource_filename(\"tests\", \"data/configs/parameters_mixed.cfg\")\n",
     "print(cfg_file_mixed)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
-    "config_name = os.path.splitext(cfg_file_mixed)[0]  # Remove .cfg extension\n",
-    "with NamedTemporaryFile(\n",
-    "    suffix=\".cfg\", prefix=os.path.basename(config_name), mode=\"w+t\"\n",
-    ") as temp_config:  # Avoid permanent replacement of https URLs\n",
-    "    read_config = open(cfg_file_mixed, \"r\")\n",
-    "    temp_config.writelines(read_config.read())\n",
-    "    temp_config.read()\n",
-    "    output = osprey.parameters(\n",
-    "        params_config = temp_config.name\n",
-    "    )"
+    "output = osprey.parameters(\n",
+    "    params_config = cfg_file_mixed\n",
+    ")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
        "parametersResponse(\n",
-       "    output='http://localhost:5002/outputs/cf30040e-f2d7-11ea-9093-c86000e3f36f/sample.rvic.prm.COLUMBIA.20200909.nc'\n",
+       "    output='http://localhost:5002/outputs/b5f96fd0-f7ae-11ea-9a48-c86000e3f36f/sample.rvic.prm.COLUMBIA.20200915.nc'\n",
        ")"
       ]
      },
-     "execution_count": null,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -247,7 +180,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -276,18 +209,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
        "parametersResponse(\n",
-       "    output='http://localhost:5002/outputs/6828fa26-f2d8-11ea-9093-c86000e3f36f/sample.rvic.prm.COLUMBIA.20200909.nc'\n",
+       "    output='http://localhost:5002/outputs/b95397dc-f7ae-11ea-9a48-c86000e3f36f/sample.rvic.prm.COLUMBIA.20200915.nc'\n",
        ")"
       ]
      },
-     "execution_count": null,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/osprey/processes/wps_parameters.py
+++ b/osprey/processes/wps_parameters.py
@@ -155,8 +155,8 @@ class Parameters(Process):
         )
 
         if os.path.isfile(unprocessed):
-            replace_urls(unprocessed, self.workdir)
-            config = read_config(unprocessed)
+            tmp_config_file = replace_urls(unprocessed, self.workdir)
+            config = read_config(tmp_config_file)
         else:
             config = config_hander(
                 self.workdir, parameters.__name__, unprocessed, self.config_template

--- a/osprey/utils.py
+++ b/osprey/utils.py
@@ -61,11 +61,13 @@ def replace_urls(config_file, outdir):
             local_file.write(r.content)
             filedata[i] = filedata[i].replace(url, local_file.name)
 
-    config_name = os.path.splitext(config_file)[0]  # Remove .cfg extension
-    with NamedTemporaryFile(suffix=".cfg", prefix=os.path.basename(config_name), mode="w+t") as temp_config:  # Avoid permanent replacement of https URLs
-        temp_config.writelines(filedata)
-    
-    return temp_config.name
+    config_filename = config_file.split("/")[-1]
+    tmp_config_file = os.path.join(outdir, config_filename)
+    with open(tmp_config_file, "w") as write_config:
+        for line in filedata:
+            write_config.write(f"{line}")
+
+    return tmp_config_file
 
 
 def config_hander(workdir, modulue_name, unprocessed, config_template):

--- a/osprey/utils.py
+++ b/osprey/utils.py
@@ -36,15 +36,15 @@ def replace_filenames(config, temp_config):
     temp_config.writelines(newdata)
 
 
-def replace_urls(config, outdir):
+def replace_urls(config_file, outdir):
     """
     Copy https URLs to local storage and replace URLs
     with local paths in config file.
     Parameters:
-        config (str): Config file
+        config_file (str): Config file
         outdir (str): Output directory
     """
-    with open(config, "r") as read_config:
+    with open(config_file, "r") as read_config:
         filedata = read_config.readlines()
 
     for i in range(len(filedata)):
@@ -61,9 +61,11 @@ def replace_urls(config, outdir):
             local_file.write(r.content)
             filedata[i] = filedata[i].replace(url, local_file.name)
 
-    with open(config, "w") as write_config:
-        for line in filedata:
-            write_config.write(f"{line}")
+    config_name = os.path.splitext(config_file)[0]  # Remove .cfg extension
+    with NamedTemporaryFile(suffix=".cfg", prefix=os.path.basename(config_name), mode="w+t") as temp_config:  # Avoid permanent replacement of https URLs
+        temp_config.writelines(filedata)
+    
+    return temp_config.name
 
 
 def config_hander(workdir, modulue_name, unprocessed, config_template):

--- a/tests/test_wps_parameters.py
+++ b/tests/test_wps_parameters.py
@@ -34,18 +34,8 @@ from osprey.utils import replace_filenames
     ],
 )
 def test_parameters_local(config):
-    if type(config) == dict:
-        params = ("params_config={0};").format(config)
-        run_wps_process(Parameters(), params)
-    else:
-        config_name = os.path.splitext(config)[0]  # Remove .cfg extension
-        with NamedTemporaryFile(
-            suffix=".cfg", prefix=os.path.basename(config_name), mode="w+t"
-        ) as temp_config:
-            replace_filenames(config, temp_config)
-            temp_config.read()
-            params = f"params_config={temp_config.name};"
-            run_wps_process(Parameters(), params)
+    params = ("params_config={0};").format(config)
+    run_wps_process(Parameters(), params)
 
 
 @pytest.mark.online
@@ -53,12 +43,5 @@ def test_parameters_local(config):
     ("config"), [resource_filename(__name__, "data/configs/parameters_https.cfg")],
 )
 def test_parameters_https(config, conftest_make_mock_urls):
-    config_name = os.path.splitext(config)[0]  # Remove .cfg extension
-    with NamedTemporaryFile(
-        suffix=".cfg", prefix=os.path.basename(config_name), mode="w+t"
-    ) as temp_config:  # Avoid permanent replacement of https URLs
-        read_config = open(config, "r")
-        temp_config.writelines(read_config.read())
-        temp_config.read()
-        params = f"params_config={temp_config.name};"
-        run_wps_process(Parameters(), params)
+    params = ("params_config={0};").format(config)
+    run_wps_process(Parameters(), params)


### PR DESCRIPTION
This PR resolves #44 

`replace_urls` is a function that stores downloaded files from `https` and modifies URLs to the stored filepaths in configuration files. Previously, it modified the content of original configuration files, which is not preferred. To avoid the problem, the function is now fixed to copy the modified content to a file in `tmp`.