### PR TITLE
Suppress sql logging

### DIFF
--- a/osprey/default.cfg
+++ b/osprey/default.cfg
@@ -18,3 +18,4 @@ parallelprocesses = 2
 level = INFO
 file = osprey.log
 format = %(asctime)s] [%(levelname)s] line=%(lineno)s module=%(module)s %(message)s
+db_echo = false

--- a/pavics-component/wps.cfg.template
+++ b/pavics-component/wps.cfg.template
@@ -3,6 +3,7 @@ outputurl = https://${PAVICS_FQDN_PUBLIC}/wpsoutputs
 outputpath = /data/wpsoutputs
 
 [logging]
-level = DEBUG
+level = INFO
+db_echo = false
 
 ${EXTRA_PYWPS_CONFIG}


### PR DESCRIPTION
Resolves #50.

```
[nrados@docker-dev03 birdhouse]$ docker logs osprey
[2020-09-29 19:54:36 +0000] [1] [INFO] Starting gunicorn 20.0.4
[2020-09-29 19:54:36 +0000] [1] [INFO] Listening at: http://0.0.0.0:5002 (1)
[2020-09-29 19:54:36 +0000] [1] [INFO] Using worker: sync
[2020-09-29 19:54:36 +0000] [8] [INFO] Booting worker with pid: 8
2020-09-29 19:54:55 INFO: osprey: Request: getcapabilities
2020-09-29 19:54:56 INFO: osprey: Request: getcapabilities
2020-09-29 19:55:01 INFO: osprey: Request: getcapabilities
2020-09-29 19:55:03 INFO: osprey: Request: getcapabilities
2020-09-29 19:56:01 INFO: osprey: Request: getcapabilities
2020-09-29 19:56:01 INFO: osprey: Request: getcapabilities
2020-09-29 19:57:02 INFO: osprey: Request: getcapabilities
2020-09-29 19:57:03 INFO: osprey: Request: getcapabilities
```