### PR TITLE
Multi-stage build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,9 @@ ENV PIP_INDEX_URL="https://pypi.pacificclimate.org/simple/"
 RUN apt-get update && apt-get install -y \
     build-essential
 
-COPY . /opt/wps
-
 WORKDIR /opt/wps
+COPY ./osprey /opt/wps/osprey
+COPY CHANGES.rst README.rst requirements.txt requirements_dev.txt setup.py ./
 
 RUN pip install --upgrade pip && \
     pip install --user . && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ WORKDIR /opt/wps
 
 RUN pip install --upgrade pip && \
     pip install --user . && \
-    pip install gunicorn
+    pip install --user gunicorn
 
 # vim:set ft=dockerfile:
 FROM python:3.8-slim AS prod
@@ -24,8 +24,7 @@ COPY --from=builder /root/.local /root/.local
 # Make sure scripts in .local are usable:
 ENV PATH=/root/.local/bin:$PATH
 
-COPY ./osprey /opt/wps
-WORKDIR /opt/wps
+WORKDIR /root/.local/lib/python3.8/dist-packages/osprey
 
 EXPOSE 5000
 CMD ["gunicorn", "--bind=0.0.0.0:5000", "osprey.wsgi:application"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,4 @@
-# vim:set ft=dockerfile:
-FROM python:3.8-slim
-MAINTAINER https://github.com/pacificclimate/osprey
-LABEL Description="osprey WPS" Vendor="pacificclimate" Version="0.1.0"
+FROM python:3.7-slim AS builder
 
 ENV PIP_INDEX_URL="https://pypi.pacificclimate.org/simple/"
 
@@ -14,8 +11,21 @@ COPY . /opt/wps
 WORKDIR /opt/wps
 
 RUN pip install --upgrade pip && \
-    pip install -e . && \
+    pip install --user . && \
     pip install gunicorn
+
+# vim:set ft=dockerfile:
+FROM python:3.7-slim AS prod
+MAINTAINER https://github.com/pacificclimate/osprey
+LABEL Description="osprey WPS" Vendor="pacificclimate" Version="0.1.0"
+
+COPY --from=builder /root/.local /root/.local
+
+# Make sure scripts in .local are usable:
+ENV PATH=/root/.local/bin:$PATH
+
+WORKDIR /opt/wps
+COPY . .
 
 EXPOSE 5000
 CMD ["gunicorn", "--bind=0.0.0.0:5000", "osprey.wsgi:application"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,12 +6,10 @@ ENV PIP_INDEX_URL="https://pypi.pacificclimate.org/simple/"
 RUN apt-get update && apt-get install -y \
     build-essential
 
-WORKDIR /opt/wps
-COPY ./osprey /opt/wps/osprey
-COPY CHANGES.rst README.rst requirements.txt requirements_dev.txt setup.py ./
+COPY requirements.txt ./
 
 RUN pip install --upgrade pip && \
-    pip install --user . && \
+    pip install --user -r requirements.txt && \
     pip install --user gunicorn
 
 # vim:set ft=dockerfile:
@@ -24,7 +22,8 @@ COPY --from=builder /root/.local /root/.local
 # Make sure scripts in .local are usable:
 ENV PATH=/root/.local/bin:$PATH
 
-WORKDIR /root/.local/lib/python3.8/dist-packages/osprey
+WORKDIR /opt/wps
+COPY ./osprey /opt/wps/osprey
 
 EXPOSE 5000
 CMD ["gunicorn", "--bind=0.0.0.0:5000", "osprey.wsgi:application"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-slim AS builder
+FROM python:3.8-slim AS builder
 
 ENV PIP_INDEX_URL="https://pypi.pacificclimate.org/simple/"
 
@@ -15,7 +15,7 @@ RUN pip install --upgrade pip && \
     pip install gunicorn
 
 # vim:set ft=dockerfile:
-FROM python:3.7-slim AS prod
+FROM python:3.8-slim AS prod
 MAINTAINER https://github.com/pacificclimate/osprey
 LABEL Description="osprey WPS" Vendor="pacificclimate" Version="0.1.0"
 
@@ -24,8 +24,8 @@ COPY --from=builder /root/.local /root/.local
 # Make sure scripts in .local are usable:
 ENV PATH=/root/.local/bin:$PATH
 
+COPY ./osprey /opt/wps
 WORKDIR /opt/wps
-COPY . .
 
 EXPOSE 5000
 CMD ["gunicorn", "--bind=0.0.0.0:5000", "osprey.wsgi:application"]


### PR DESCRIPTION
resolves #72 

Test port: 30124

The final image size is reduced from 769MB to 434MB after the multi-stage build. The multi-stage build creates two separate images for `build` and `execution` using two `FROM` statements. All of the dependency installations are done in the build (intermediate) image and only necessary artifacts are copied to the execution (final) image.

```
REPOSITORY                  TAG                IMAGE ID       CREATED          SIZE
pcic/osprey                 multi-stage        1b1d586c91e3   20 minutes ago   434MB
```

`wps_convert_demo` is failing due to issue #74, which is identified after Dockerfile is modified to the multi-stage build.