### PR TITLE
UHS Bug

### DIFF
--- a/osprey/processes/wps_convert.py
+++ b/osprey/processes/wps_convert.py
@@ -28,7 +28,7 @@ class Convert(Process):
                 "UHS_Files",
                 abstract="Path to UHS file",
                 min_occurs=1,
-                supported_formats=[Format('text/plain', extension='.uhs_s2'),],
+                supported_formats=[Format("text/plain", extension=".uhs_s2"),],
             ),
             ComplexInput(
                 "station_file",

--- a/osprey/processes/wps_convert.py
+++ b/osprey/processes/wps_convert.py
@@ -71,6 +71,12 @@ class Convert(Process):
         )
 
     def edit_config_file(self, config_file, uhs_files, station_file, domain):
+        with open(station_file, "r") as f:
+            data = f.readlines()
+        data[1] = uhs_files
+        with open(station_file, "w") as f:
+            f.writelines(data)
+
         parser = configparser.ConfigParser()
         parser.optionxform = str
 

--- a/osprey/processes/wps_convert.py
+++ b/osprey/processes/wps_convert.py
@@ -28,7 +28,7 @@ class Convert(Process):
                 "UHS_Files",
                 abstract="Path to UHS file",
                 min_occurs=1,
-                supported_formats=[FORMATS.TEXT],
+                supported_formats=[Format('text/plain', extension='.uhs_s2'),],
             ),
             ComplexInput(
                 "station_file",


### PR DESCRIPTION
Resolves #83 

It seems that the file was already being uploaded to the Docker server, but that the [function](https://github.com/pacificclimate/rvic-daccs/blob/2fd337a122d12499dd4b7ad1ffd8393b7d517bc1/rvic/core/convert.py#L45) was looking for a file path specified in the `station_file`. The fix was to write the path of the uhs file saved on the Docker server to the station file.

Test on port `30103`