### PR TITLE
I93 resolve dependencies

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8]
 
     steps:
     - uses: actions/checkout@v2

--- a/osprey/config_templates.py
+++ b/osprey/config_templates.py
@@ -23,8 +23,13 @@ params_config_template = OrderedDict(
             "CONSTRAIN_FRACTIONS": False,
             "SEARCH_FOR_CHANNEL": False,
         },
-        "POUR_POINTS": {"FILE_NAME": None,},
-        "UH_BOX": {"FILE_NAME": None, "HEADER_LINES": 1,},
+        "POUR_POINTS": {
+            "FILE_NAME": None,
+        },
+        "UH_BOX": {
+            "FILE_NAME": None,
+            "HEADER_LINES": 1,
+        },
         "ROUTING": {
             "FILE_NAME": None,
             "LONGITUDE_VAR": "lon",

--- a/osprey/processes/wps_convert.py
+++ b/osprey/processes/wps_convert.py
@@ -20,7 +20,8 @@ import configparser
 class Convert(Process):
     def __init__(self):
         self.status_percentage_steps = dict(
-            common_status_percentages, **{"config_rebuild": 10},
+            common_status_percentages,
+            **{"config_rebuild": 10},
         )
         inputs = [
             log_level,
@@ -29,7 +30,9 @@ class Convert(Process):
                 "UHS_Files",
                 abstract="Path to UHS file",
                 min_occurs=1,
-                supported_formats=[Format("text/plain", extension=".uhs_s2"),],
+                supported_formats=[
+                    Format("text/plain", extension=".uhs_s2"),
+                ],
             ),
             ComplexInput(
                 "station_file",

--- a/osprey/processes/wps_convolution.py
+++ b/osprey/processes/wps_convolution.py
@@ -18,7 +18,8 @@ from osprey import io
 class Convolution(Process):
     def __init__(self):
         self.status_percentage_steps = dict(
-            common_status_percentages, **{"config_rebuild": 10},
+            common_status_percentages,
+            **{"config_rebuild": 10},
         )
         inputs = [
             log_level,

--- a/osprey/processes/wps_parameters.py
+++ b/osprey/processes/wps_parameters.py
@@ -34,7 +34,8 @@ import os
 class Parameters(Process):
     def __init__(self):
         self.status_percentage_steps = dict(
-            common_status_percentages, **{"config_rebuild": 10},
+            common_status_percentages,
+            **{"config_rebuild": 10},
         )
         inputs = [
             log_level,

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -4,7 +4,6 @@ pytest-flake8
 requests-mock
 ipython
 pytest-notebook
-nbclient~=0.5.9
 nbsphinx
 nbval>=0.9.6
 nbconvert
@@ -14,6 +13,7 @@ twine
 cruft
 # Changing dependencies above this comment will create merge conflicts when updating the cookiecutter template with cruft. Add extra requirements below this line.
 black==19.10b0
+nbclient~=0.5.10
 
 # notebook requirements
 jupyterlab==3.0.14

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -12,7 +12,7 @@ bumpversion
 twine
 cruft
 # Changing dependencies above this comment will create merge conflicts when updating the cookiecutter template with cruft. Add extra requirements below this line.
-black==19.10b0
+black==22.3.0
 nbclient~=0.5.10
 
 # notebook requirements

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -4,6 +4,7 @@ pytest-flake8
 requests-mock
 ipython
 pytest-notebook
+nbclient==0.5.10
 nbsphinx
 nbval>=0.9.6
 nbconvert
@@ -19,4 +20,5 @@ jupyterlab==3.0.14
 ipywidgets
 nodejs
 birdhouse-birdy
-beautifulsoup4
+beautifulsoup4==4.9.3
+setuptools==60.2.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -4,7 +4,7 @@ pytest-flake8
 requests-mock
 ipython
 pytest-notebook
-nbclient==0.5.10
+nbclient~=0.5.9
 nbsphinx
 nbval>=0.9.6
 nbconvert

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,12 @@ setup(
     },
     include_package_data=True,
     install_requires=reqs,
-    extras_require={"dev": dev_reqs,},  # pip install ".[dev]"
-    entry_points={"console_scripts": ["osprey=osprey.cli:cli",]},
+    extras_require={
+        "dev": dev_reqs,
+    },  # pip install ".[dev]"
+    entry_points={
+        "console_scripts": [
+            "osprey=osprey.cli:cli",
+        ]
+    },
 )

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ from setuptools import setup, find_packages
 here = os.path.abspath(os.path.dirname(__file__))
 README = open(os.path.join(here, "README.md")).read()
 CHANGES = open(os.path.join(here, "CHANGES.md")).read()
-REQUIRES_PYTHON = ">=3.5.0"
+REQUIRES_PYTHON = ">=3.7.0"
 
 about = {}
 with open(os.path.join(here, "osprey", "__version__.py"), "r") as f:
@@ -28,9 +28,8 @@ classifiers = [
     "Programming Language :: Python",
     "Natural Language :: English",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.5",
-    "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
     "Topic :: Scientific/Engineering :: Atmospheric Science",
     "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
 ]

--- a/tests/test_wps_convolution.py
+++ b/tests/test_wps_convolution.py
@@ -88,7 +88,11 @@ def build_params(
             local_path("samples/sample.rvic.prm.COLUMBIA.20180516.nc"),
             url_path("columbia_vicset2.nc", "opendap", "climate_explorer_data_prep"),
             None,
-            {"OPTIONS": {"CASESTR": "Historical",},},
+            {
+                "OPTIONS": {
+                    "CASESTR": "Historical",
+                },
+            },
         ),
     ],
 )

--- a/tests/test_wps_full_rvic.py
+++ b/tests/test_wps_full_rvic.py
@@ -128,8 +128,16 @@ def test_full_rvic_local_pour_points(
             url_path("columbia_vicset2.nc", "opendap", "climate_explorer_data_prep"),
             None,
             None,
-            {"OPTIONS": {"LOG_LEVEL": "CRITICAL",},},
-            {"OPTIONS": {"CASESTR": "Historical",},},
+            {
+                "OPTIONS": {
+                    "LOG_LEVEL": "CRITICAL",
+                },
+            },
+            {
+                "OPTIONS": {
+                    "CASESTR": "Historical",
+                },
+            },
         ),
     ],
 )

--- a/tests/test_wps_parameters.py
+++ b/tests/test_wps_parameters.py
@@ -48,7 +48,11 @@ from .utils import process_err_test
             local_path("samples/sample_flow_parameters.nc"),
             local_path("samples/sample_routing_domain.nc"),
             None,
-            {"OPTIONS": {"LOG_LEVEL": "CRITICAL",},},
+            {
+                "OPTIONS": {
+                    "LOG_LEVEL": "CRITICAL",
+                },
+            },
         ),
     ],
 )
@@ -131,7 +135,11 @@ def test_parameters_local(
             ),
             url_path("sample_routing_domain.nc", "http", "climate_explorer_data_prep"),
             None,
-            {"OPTIONS": {"LOG_LEVEL": "CRITICAL",},},
+            {
+                "OPTIONS": {
+                    "LOG_LEVEL": "CRITICAL",
+                },
+            },
         ),
     ],
 )


### PR DESCRIPTION
This PR resolves #93. In doing so, versions of `beautifulsoup4`, `setuptools`, and `nbclient` have been pinned, `black` has been updated, and support for Python 3.6 has dropped.