### PR TITLE
Pin rvic-daccs to version 1.1.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ pywps==4.4.2
 jinja2
 click
 psutil
-rvic-daccs==1.1.5
+rvic-daccs==1.1.6
 nchelpers==5.5.7
 werkzeug==1.0.1
 wps-tools==2.0.0


### PR DESCRIPTION
This PR resolves #95. `rvic-daccs` is set to version 1.1.6 in `requirements.txt`.